### PR TITLE
feat(design): Adding new griddb design

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sqlite diff=sqlite3

--- a/.justfile
+++ b/.justfile
@@ -1,4 +1,5 @@
-db-name := "example.db"
+db-name := "griddb-example.sqlite"
+query-file := "queries.sql"
 data := "dummy_data.sql"
 sqlite-options := "--table"
 tmpdir := `mktemp -d`
@@ -8,18 +9,23 @@ sqlite-command := "sqlite3"
 assert-sqlite-version:
     @{{sqlite-command}} --version
 
-create-schema: assert-sqlite-version
+create-schema db=db-name: assert-sqlite-version
     @echo "Creating schema"
-    @rm {{db-name}}
-    @{{sqlite-command}} {{db-name}} < schema.sql
+    @rm {{db}}
+    @{{sqlite-command}} {{db}} < schema.sql
 
-load-dummy-data: create-schema
+load-dummy-data db=db-name: create-schema
     @echo "Loading dummy data"
-    @{{sqlite-command}} {{db-name}} < {{data}}
+    @{{sqlite-command}} {{db}} < {{data}}
 
-new-db: load-dummy-data
-    @{{sqlite-command}} {{sqlite-options}} {{db-name}}
+new-db db=db-name: load-dummy-data
+    @{{sqlite-command}} {{sqlite-options}} {{db}}
 
-test: load-dummy-data
-    @echo "Running queries"
-    @{{sqlite-command}} {{sqlite-options}} {{db-name}} < queries.sql
+query db=db-name:
+    @echo "Running query file to {{db}}"
+    @{{sqlite-command}} {{sqlite-options}} {{db}} < {{query-file}}
+
+test db=db-name:
+    @echo "Running test sequence on {{db}}..."
+    @just load-dummy-data {{db}}
+    @just query {{db}}

--- a/.justfile
+++ b/.justfile
@@ -1,0 +1,25 @@
+db-name := "example.db"
+data := "dummy_data.sql"
+sqlite-options := "--table"
+tmpdir := `mktemp -d`
+SQLITE_REQUIRED_VERSION := "3.35.0"
+sqlite-command := "sqlite3"
+
+assert-sqlite-version:
+    @{{sqlite-command}} --version
+
+create-schema: assert-sqlite-version
+    @echo "Creating schema"
+    @rm {{db-name}}
+    @{{sqlite-command}} {{db-name}} < schema.sql
+
+load-dummy-data: create-schema
+    @echo "Loading dummy data"
+    @{{sqlite-command}} {{db-name}} < {{data}}
+
+new-db: load-dummy-data
+    @{{sqlite-command}} {{sqlite-options}} {{db-name}}
+
+test: load-dummy-data
+    @echo "Running queries"
+    @{{sqlite-command}} {{sqlite-options}} {{db-name}} < queries.sql

--- a/.justfile
+++ b/.justfile
@@ -14,7 +14,15 @@ create-schema db=db-name: assert-sqlite-version
     @rm {{db}}
     @{{sqlite-command}} {{db}} < schema.sql
 
-load-dummy-data db=db-name: create-schema
+create-triggers db=db-name: create-schema
+    @echo "Adding triggers to schema"
+    @{{sqlite-command}} {{db}} < triggers.sql
+
+create-views db=db-name: create-schema
+    @echo "Adding views to schema"
+    @{{sqlite-command}} {{db}} < views.sql
+
+load-dummy-data db=db-name: create-schema create-triggers create-views
     @echo "Loading dummy data"
     @{{sqlite-command}} {{db}} < {{data}}
 
@@ -29,3 +37,14 @@ test db=db-name:
     @echo "Running test sequence on {{db}}..."
     @just load-dummy-data {{db}}
     @just query {{db}}
+
+format sql-schema:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    echo "Formatting code {{sql-schema}}"
+    if command -v sleek &> /dev/null; then
+        sleek {{sql-schema}}
+    else
+        echo "SQL formatter does not exist. Installed it using `cargo install sleek`"
+        exit 1
+    fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,40 @@
 
 Schema for the SQL database for Sienna Applications
 
-## Set pre-commit environment
+> [!IMPORTANT]
+> The griddb schema was designed using SQLite 3.45 to use some of the jsonb
+> functionality. We do not intend to provide backwards compatibility since when
+> we deisgined this 3.45 had already a year of being deployed.
+
+## How To(s)
+
+### How to install `just`
+
+> [!NOTE]
+> The recommended method to install just is using cargo.
+> However, there are multiple ways of installing it see the `just` documentation for [just](https://github.com/casey/just)
+
+```console
+cargo install just
+```
+
+### Create and example database and run some queries on it
+
+```console
+just test
+```
+
+### Run example queries on a griddb schema database
+
+To create a database with the schema use the following command:
+
+```console
+just queries $DB_NAME
+```
+
+## Contributing
+
+### Set pre-commit environment
 
 Install a virtual environment
 
@@ -20,18 +53,4 @@ Setup pre-commit to run automatically on each commit.
 
 ```console
 pre-commit install
-```
-
-## How to create the Schema
-
-To create a database with the schema use the following command:
-
-```console
-sqlite3 test.db < schema.sql
-```
-
-Testing data with some basic queries:
-
-```console
-sqlite3 -table < dummy_data.sql
 ```

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -1,49 +1,52 @@
 PRAGMA foreign_keys = ON;
-INSERT INTO prime_movers (prime_mover, fuel, description) VALUES
-('CT', 'Oil', "[C]ombustion [T]urbine wiht Oil"),
-('CT', 'NG', "[C]ombustion [T]urbine with [N]atural [G]as"),
-('HY', NULL, "[HY]droelectric"),
-('WT', NULL, "[W]ind [T]urbine"),
-('BA', NULL, "Energy Storage, [BA]ttery"),
-('PV', NULL, "[P]hoto[V]oltaic");
---
--- -- Areas are the higher level aggregation of balancing topologies
+INSERT INTO prime_mover_types (name, description) VALUES
+('CT', "[C]ombustion [T]urbine"),
+('HY', "[HY]droelectric"),
+('WT', "[W]ind [T]urbine"),
+('BA', "Energy Storage, [BA]ttery"),
+('PS', "[P]ump [S]torage"),
+('PV', "[P]hoto[V]oltaic");
+
+INSERT INTO fuels(name, description) VALUES
+("NG", "[N]atural [G]as"), ("Oil", "Oil");
+
+-- Areas are the higher level aggregation of balancing topologies
 INSERT INTO planning_regions (name, description) VALUES
 ('North', 'Northern region'),
 ('South', 'Southern region');
---
--- -- Balancing topologies are the lower level aggregation of generation units
-INSERT INTO balancing_topologies (name, area, participation_factor, description) VALUES
-('load_area_01', 'North', 0.25, 'Urban area with high power demand'),
-('load_area_02', 'South', 0.35, 'Rural area with moderate power demand'),
-('load_area_03', 'North', 0.25, 'Industrial area with heavy power consumption'),
-('load_area_04', 'South', 0.25,  'Commercial area with varying power requirements'),
-('region_01', 'North',  0.25,'Urban area with generation from Natural Gas'),
-('region_02', 'South', 0.35, 'Rural area with generation from hydro'),
-('region_03', 'North', 0.25, 'Industrial area with generation from solar and storage'),
-('region_04', 'South', 0.25, 'Commercial area with generation from wind and storage');
--- --
--- -- -- Inserting data for generation units
+
+-- Balancing topologies are the lower level aggregation of generation units
+INSERT INTO balancing_topologies (name, area, description) VALUES
+('load_area_01', 'North', 'Urban area with high power demand'),
+('load_area_02', 'South', 'Rural area with moderate power demand'),
+('load_area_03', 'North', 'Industrial area with heavy power consumption'),
+('load_area_04', 'South',  'Commercial area with varying power requirements'),
+('region_01', 'North'  ,'Urban area with generation from Natural Gas'),
+('region_02', 'South', 'Rural area with generation from hydro'),
+('region_03', 'North', 'Industrial area with generation from solar and storage'),
+('region_04', 'South', 'Commercial area with generation from wind and storage');
+
+-- Inserting data for generation units
 INSERT INTO generation_units (
-    name, prime_mover, fuel, balancing_topology, rating, base_power, start_year
+    name, prime_mover, fuel, balancing_topology, rating, base_power
 ) VALUES
-('Unit 1', 'CT', 'NG', 'region_01', 200, 200, 2020),
-('Unit 2', 'HY', NULL, 'region_02', 300, 300, 2020),
-('Unit 3', 'PV', NULL, 'region_03', 150, 200, 2020),
-('Unit 4', 'WT', NULL, 'region_04', 180, 200, 2020);
---
+('Unit 1', 'CT', 'NG', 'region_01', 1, 200),
+('Unit 2', 'HY', NULL, 'region_02', 1, 300),
+('Unit 3', 'PV', NULL, 'region_03', 1, 200),
+('Unit 4', 'WT', NULL, 'region_04', 1, 200);
+
 -- Inserting data for storage units
 INSERT INTO storage_units (
-    id, name, prime_mover, max_capacity, discharge_efficiency, balancing_topology, rating, base_power, start_year
+    name, prime_mover, max_capacity, efficiency_up, balancing_topology, rating, base_power
 ) VALUES
-(1, 'Storage Unit 2',"PS",  600.0, 1.0, 'region_04', 300, 300, 2020),
-(2, 'Storage Unit 3',"PS",  900.0, 0.95, 'region_03', 150, 300, 2020),
-(3, 'Storage Unit 4',"PS", 1200.0, 1.0, 'region_02', 180, 300, 2020);
+('Storage Unit 2',"PS",  600.0, 1.0, 'region_04', 1, 300),
+('Storage Unit 3',"PS",  900.0, 0.95, 'region_03', 1, 300),
+('Storage Unit 4',"PS", 1200.0, 1.0, 'region_02', 1, 300);
 
 -- Insert some arcs
-INSERT INTO arcs (from_to, to_from) VALUES (1, 2);
-INSERT INTO arcs (from_to, to_from) VALUES (3, 4);
-INSERT INTO arcs (from_to, to_from) VALUES (5, 6);
+INSERT INTO arcs (from_to, to_from) VALUES (11, 12);
+INSERT INTO arcs (from_to, to_from) VALUES (13, 14);
+INSERT INTO arcs (from_to, to_from) VALUES (15, 16);
 
 -- Inserting data for transmission lines
 INSERT INTO transmission_lines (
@@ -53,13 +56,16 @@ INSERT INTO transmission_lines (
 (3, 175.0, 193.0, 200.0, 22.0);
 
 -- Inserting data for investment technologies
-INSERT INTO supply_technologies (prime_mover, fuel, vom_cost, fom_cost, balancing_topology, scenario)
+INSERT INTO supply_technologies (prime_mover, fuel, balancing_topology, scenario)
 VALUES
-("WT", NULL, 0.0, 0.0, "region_01", NULL),
-("WT", NULL, 10.0, 0.0, "region_01", "Expensive"),
-("PV", NULL,0.0, 0.0, "region_02", NULL);
+("WT", NULL,"region_01", NULL),
+("WT", NULL, "region_01", "Expensive"),
+("CT", "NG", "region_01", "Expensive"),
+("PV", NULL, "region_02", NULL);
 
 -- Supplemental attributes
+INSERT INTO supplemental_attributes (type, value) VALUES
+    ('outage', jsonb("[0,1,2,3]"));
 INSERT INTO supplemental_attributes (type, value) VALUES
     ('geolocation', jsonb("{'lat': 30.5, 'lon': -99.5}"));
 
@@ -70,7 +76,7 @@ INSERT INTO supplemental_attributes_association (attribute_id, entity_id) values
 INSERT INTO time_series (time_series_type, name, initial_timestamp, resolution_ms, horizon, interval, length, metadata)
 VALUES
 -- Hourly time series for a day (24 points)
-('SingleTimeSeries', 'active_power', '2025-01-01 00:00:00', 3600000, 1, 1, 12, '{"unit": "MW"}'),
+('SingleTimeSeries', 'active_power', '2025-01-01 00:00:00', 3600, 1, 1, 12, '{"unit": "MW"}'),
 ('DeterministicTimeSeries', 'active_power', '2025-01-01 00:00:00', 43200000, 4, 1, 24, '{"unit": "MW"}'),
 ('SingleTimeSeries', 'montly_budget', '2025-01-01 00:00:00', 2592000000, 1, 1, 12, '{"unit": "MWh"}'),
 ('SingleTimeSeries', 'investment', '2025-01-01 00:00:00', 2592000000, 1, 1, 1, '{"unit": "MWh"}');
@@ -119,7 +125,7 @@ WITH RECURSIVE time_points(n, timestamp) AS (
     FROM time_points
     WHERE n < 23
 )
-INSERT INTO deterministic_time_series (time_series_id, timestamp, value)
+INSERT INTO deterministic_forecast_time_series (time_series_id, timestamp, value)
 SELECT
     2 AS time_series_id,
     timestamp,

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -1,149 +1,127 @@
-INSERT INTO prime_mover_types (prime_mover, fuel_type) VALUES
-('CT', 'Oil'),
-('STEAM', 'Coal'),
-('CT', 'NG'),
-('HYDRO', 'Hydro'),
-('WIND', 'Wind'),
-('STORAGE', 'Storage'),
-('PV', 'Solar');
-
--- Areas are the higher level aggregation of balancing topologies
+PRAGMA foreign_keys = ON;
+INSERT INTO prime_movers (prime_mover, fuel, description) VALUES
+('CT', 'Oil', "[C]ombustion [T]urbine wiht Oil"),
+('CT', 'NG', "[C]ombustion [T]urbine with [N]atural [G]as"),
+('HY', NULL, "[HY]droelectric"),
+('WT', NULL, "[W]ind [T]urbine"),
+('BA', NULL, "Energy Storage, [BA]ttery"),
+('PV', NULL, "[P]hoto[V]oltaic");
+--
+-- -- Areas are the higher level aggregation of balancing topologies
 INSERT INTO areas (name, description) VALUES
 ('North', 'Northern region'),
 ('South', 'Southern region');
-
--- Balancing topologies are the lower level aggregation of generation units
-INSERT INTO balancing_topologies (name, area, description, participation_factor) VALUES
-('Load Area 1', 'North', 'Urban area with high power demand', 0.25),
-('Load Area 2', 'South', 'Rural area with moderate power demand', 0.35),
-('Load Area 3', 'North', 'Industrial area with heavy power consumption', 0.25),
-('Load Area 4', 'South', 'Commercial area with varying power requirements', 0.15),
-('Topo 1', 'North', 'Urban area with generation from Natural Gas', 0.25),
-('Topo 2', 'South', 'Rural area with generation from hydro', 0.35),
-('Topo 3', 'North', 'Industrial area with generation from solar and storage', 0.25),
-('Topo 4', 'South', 'Commercial area with generation from wind and storage', 0.15);
-
--- Inserting data for generation units
+--
+-- -- Balancing topologies are the lower level aggregation of generation units
+INSERT INTO balancing_topologies (name, area, participation_factor, description) VALUES
+('load_area_01', 'North', 0.25, 'Urban area with high power demand'),
+('load_area_02', 'South', 0.35, 'Rural area with moderate power demand'),
+('load_area_03', 'North', 0.25, 'Industrial area with heavy power consumption'),
+('load_area_04', 'South', 0.25,  'Commercial area with varying power requirements'),
+('region_01', 'North',  0.25,'Urban area with generation from Natural Gas'),
+('region_02', 'South', 0.35, 'Rural area with generation from hydro'),
+('region_03', 'North', 0.25, 'Industrial area with generation from solar and storage'),
+('region_04', 'South', 0.25, 'Commercial area with generation from wind and storage');
+-- --
+-- -- -- Inserting data for generation units
 INSERT INTO generation_units (
-    unit_id, name, prime_mover, fuel_type, balancing_topology, rating, base_power
+    name, prime_mover, fuel, balancing_topology, rating, base_power, start_year
 ) VALUES
-(1, 'Unit 1', 'CT', 'NG', 'Topo 1', 200, 200),
-(2, 'Unit 2', 'HYDRO', 'Hydro', 'Topo 2', 300, 300),
-(3, 'Unit 3', 'PV', 'Solar', 'Topo 3', 150, 200),
-(4, 'Unit 4', 'WIND', 'Wind', 'Topo 4', 180, 200);
-
+('Unit 1', 'CT', 'NG', 'region_01', 200, 200, 2020),
+('Unit 2', 'HY', NULL, 'region_02', 300, 300, 2020),
+('Unit 3', 'PV', NULL, 'region_03', 150, 200, 2020),
+('Unit 4', 'WT', NULL, 'region_04', 180, 200, 2020);
+--
 -- Inserting data for storage units
 INSERT INTO storage_units (
-    storage_unit_id, name, prime_mover, fuel_type, max_capacity, round_trip_efficiency, balancing_topology, rating, base_power
+    id, name, prime_mover, max_capacity, discharge_efficiency, balancing_topology, rating, base_power, start_year
 ) VALUES
-(1, 'Storage Unit 2', 'HYDRO', 'Hydro', 600.0, 1.0, 'Topo 2', 300, 300),
-(2, 'Storage Unit 3', 'STORAGE', 'Storage', 900.0, 0.95, 'Topo 3', 150, 300),
-(3, 'Storage Unit 4', 'HYDRO', 'Hydro', 1200.0, 1.0,'Topo 4', 180, 300);
+(1, 'Storage Unit 2',"PS",  600.0, 1.0, 'region_04', 300, 300, 2020),
+(2, 'Storage Unit 3',"PS",  900.0, 0.95, 'region_03', 150, 300, 2020),
+(3, 'Storage Unit 4',"PS", 1200.0, 1.0, 'region_02', 180, 300, 2020);
+
+-- Insert some arcs
+INSERT INTO arcs (from_to, to_from) VALUES (1, 2);
+INSERT INTO arcs (from_to, to_from) VALUES (3, 4);
+INSERT INTO arcs (from_to, to_from) VALUES (5, 6);
 
 -- Inserting data for transmission lines
 INSERT INTO transmission_lines (
-    area_from, area_to, continuous_rating, ste_rating, lte_rating, line_length
+    arc_id, continuous_rating, ste_rating, lte_rating, line_length
 ) VALUES
-('Load Area 1', 'Load Area 2', 175.0, 193.0, 200.0, 22.0),
-('Load Area 1', 'Topo 1', 200.0, 220.0, 250.0, 25.0),
-('Load Area 2', 'Topo 1', 300.0, 330.0, 400.0, 40.0),
-('Topo 3', 'Load Area 3', 150.0, 165.0, 180.0, 18.0),
-('Topo 3', 'Topo 4', 180.0, 198.0, 220.0, 22.0),
-('Load Area 2', 'Load Area 3', 400.0, 510.0, 600.0, 55.0),
-('Load Area 3', 'Load Area 4', 175.0, 208.0, 220.0, 22.0);
-
--- If there are time series or piecewise linear additions, an attribute must be created for data relation maintenance
-INSERT INTO attributes (entity_id, entity_type, name, data_type) VALUES
-(1, 'generation_units', 'wind_generation_curve', 'time_series'),
-(2, 'generation_units', 'solar_generation_curve', 'time_series'),
-(3, 'generation_units', 'hydro_generation_curve', 'time_series'),
-(4, 'demand_requirements', 'Load Area 1', 'time_series'),
-(5, 'demand_requirements', 'Load Area 2', 'time_series');
-
-INSERT INTO demand_requirements (entity_attribute_id, peak_load, area) VALUES
-(4, 1000, 'North'),
-(5, 2000, 'South');
-
-
--- Once the attribute is created, the time series data for the load can be inserted into the blob
--- Insert time series data as JSON blob
-INSERT INTO time_series (entity_attribute_id, time_series_blob) VALUES
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+1 hour'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+2 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+3 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+4 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+5 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+6 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+7 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+8 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+9 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+10 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+11 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+12 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+13 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+14 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+15 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+16 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+17 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+18 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+19 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+20 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+21 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+22 hours'), 'value', random() * 100)),
-(4, json_object('timestamp', strftime('%s', 'now', 'start of day', '+23 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+1 hour'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+2 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+3 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+4 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+5 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+6 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+7 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+8 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+9 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+10 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+11 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+12 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+13 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+14 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+15 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+16 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+17 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+18 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+19 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+20 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+21 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+22 hours'), 'value', random() * 100)),
-(5, json_object('timestamp', strftime('%s', 'now', 'start of day', '+23 hours')));
-
--- Time series data can also be added for the wind and solar generation curves
-
+(2, 175.0, 193.0, 200.0, 22.0),
+(3, 175.0, 193.0, 200.0, 22.0);
 
 -- Inserting data for investment technologies
-INSERT INTO supply_technologies (technology_id, prime_mover, fuel_type, technology_class, vom_cost, fom_cost, balancing_topology)
+INSERT INTO supply_technologies (prime_mover, fuel, vom_cost, fom_cost, balancing_topology, scenario)
 VALUES
-(1, "WIND", "Wind", 1, 0.0, 0.0, "Topo 1"),
-(2, "SOLAR", "Solar", 1, 0.0, 0.0, "Topo 2");
+("WT", NULL, 0.0, 0.0, "region_01", NULL),
+("WT", NULL, 10.0, 0.0, "region_01", "Expensive"),
+("PV", NULL,0.0, 0.0, "region_02", NULL);
 
--- Again, for piecewise linear data an attribute must be created to connect the function data to the investment technology
-INSERT INTO attributes (entity_attribute_id, entity_id, entity_type, name, data_type)
-VALUES 
-(6, 1, 'supply_technologies', 'Wind_class1', 'piecewise_linear'),
-(7, 2, 'supply_technologies', 'Solar_class1', 'piecewise_linear');
+-- Supplemental attributes
+INSERT INTO supplemental_attributes (type, value) VALUES
+    ('geolocation', jsonb("{'lat': 30.5, 'lon': -99.5}"));
 
--- x values are in MW capacity built, y is $/MW as you insert into the piecewise_linear blob
-INSERT INTO piecewise_linear (entity_attribute_id, piecewise_linear_blob)
+-- Add supplemental attribute to some entities
+INSERT INTO attributes_associations(attribute_id, entity_id) values (1, 3);
+
+-- Add time series examples
+INSERT INTO time_series (time_series_type, name, initial_timestamp, resolution_ms, horizon, interval, length, metadata)
 VALUES
-(6, '{"from_x": 0, "to_x": 100, "from_y": 0, "to_y": 100}'),
-(6, '{"from_x": 100, "to_x": 200, "from_y": 100, "to_y": 250}'),
-(6, '{"from_x": 200, "to_x": 300, "from_y": 250, "to_y": 390}'),
-(7, '{"from_x": 0, "to_x": 100, "from_y": 0, "to_y": 100}'),
-(7, '{"from_x": 100, "to_x": 200, "from_y": 100, "to_y": 250}'),
-(7, '{"from_x": 200, "to_x": 300, "from_y": 250, "to_y": 390}');
+-- Hourly time series for a day (24 points)
+('SingleTimeSeries', 'active_power', '2025-01-01 00:00:00', 3600000, 1, 1, 12, '{"unit": "MW"}'),
+('DeterministicTimeSeries', 'active_power', '2025-01-01 00:00:00', 43200000, 4, 1, 24, '{"unit": "MW"}'),
+('SingleTimeSeries', 'montly_budget', '2025-01-01 00:00:00', 2592000000, 1, 1, 12, '{"unit": "MWh"}'),
+('SingleTimeSeries', 'investment', '2025-01-01 00:00:00', 2592000000, 1, 1, 1, '{"unit": "MWh"}');
 
--- Extraneous data such as policy information can be added to the attributes table
-INSERT INTO attributes (entity_attribute_id, entity_id, entity_type, name, value, data_type)
-VALUES 
-(8, 1, 'policy_data', 'RPS_fraction_North', 0.2, 'float'),
-(9, 1, 'policy_data', 'RPS_fraction_South', 0.7, 'float');
+-- Associate time series with entities
+INSERT INTO time_series_associations (time_series_id, owner_id)
+VALUES
+(1, 11),
+(2, 11),
+(3, 12),
+(4, 3);
+
+-- Hourly time series
+INSERT INTO static_time_series (time_series_id, timestamp, value)
+VALUES
+(1, strftime('%s', 'now', 'start of day'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+1 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+2 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+3 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+4 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+5 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+6 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+7 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+8 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+9 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+10 hour'), random() * 100),
+(1, strftime('%s', 'now', 'start of day', '+11 hour'), random() * 100);
+
+-- Monthly time series
+INSERT INTO static_time_series (time_series_id, timestamp, value)
+VALUES
+(3, strftime('%s', 'now', 'start of day'), random()),
+(3, strftime('%s', 'now', 'start of day', '+30 days'), random()),
+(3, strftime('%s', 'now', 'start of day', '+60 days'), random());
+
+-- Year time series
+INSERT INTO static_time_series (time_series_id, timestamp, value)
+VALUES
+(4, strftime('%s', 'now', 'start of year'), random());
+
+-- Generate 30-minute active_power time series
+WITH RECURSIVE time_points(n, timestamp) AS (
+    SELECT 0, datetime('now', 'start of day')
+    UNION ALL
+    SELECT n+1, datetime(timestamp, '+30 minutes')
+    FROM time_points
+    WHERE n < 23
+)
+INSERT INTO deterministic_time_series (time_series_id, timestamp, value)
+SELECT
+    2 AS time_series_id,
+    timestamp,
+    jsonb_array(random(), random(), random(), random()) AS value -- 4 horizons
+FROM time_points;

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -8,7 +8,7 @@ INSERT INTO prime_movers (prime_mover, fuel, description) VALUES
 ('PV', NULL, "[P]hoto[V]oltaic");
 --
 -- -- Areas are the higher level aggregation of balancing topologies
-INSERT INTO areas (name, description) VALUES
+INSERT INTO planning_regions (name, description) VALUES
 ('North', 'Northern region'),
 ('South', 'Southern region');
 --
@@ -64,7 +64,7 @@ INSERT INTO supplemental_attributes (type, value) VALUES
     ('geolocation', jsonb("{'lat': 30.5, 'lon': -99.5}"));
 
 -- Add supplemental attribute to some entities
-INSERT INTO attributes_associations(attribute_id, entity_id) values (1, 3);
+INSERT INTO supplemental_attributes_association (attribute_id, entity_id) values (1, 3);
 
 -- Add time series examples
 INSERT INTO time_series (time_series_type, name, initial_timestamp, resolution_ms, horizon, interval, length, metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,8 @@ convention = "numpy"
 
 [tool.sqlfluff.core]
 dialect = "postgres"
+
+[dependency-groups]
+dev = [
+    "pre-commit>=3.5.0",
+]

--- a/queries.sql
+++ b/queries.sql
@@ -4,11 +4,11 @@ SELECT * from prime_movers;
 
 SELECT * from balancing_topologies;
 
-SELECT * from areas;
+SELECT * from planning_regions;
 
 SELECT * from generation_units;
 
-SELECT * from storage_units;
+SELECT id, name, max_capacity, round_trip_efficiency from storage_units;
 
 SELECT * from supply_technologies;
 
@@ -16,10 +16,33 @@ SELECT * from transmission_lines;
 
 SELECT * from arcs;
 
-SELECT id, type, json_extract(value, "$.lat") as latitude, json_extract(value, "$.lon") as longitude from supplemental_attributes;
+SELECT
+  id,
+  type,
+  json_extract(value, "$.lat") as latitude,
+  json_extract(value, "$.lon") as longitude
+FROM
+  supplemental_attributes
+WHERE
+  type == 'geolocation';
 
-SELECT * from time_series;
+SELECT
+  time_series_type,
+  name,
+  initial_timestamp,
+  resolution_ms,
+  horizon,
+  interval,
+  length
+FROM
+  time_series;
 
-SELECT id, time_series_id, datetime(timestamp, 'unixepoch'), value from static_time_series;
+SELECT
+  id,
+  time_series_id,
+  datetime (timestamp, 'unixepoch'),
+  value
+FROM
+  static_time_series;
 
 SELECT * from deterministic_time_series_view;

--- a/queries.sql
+++ b/queries.sql
@@ -1,0 +1,25 @@
+SELECT * from entities;
+
+SELECT * from prime_movers;
+
+SELECT * from balancing_topologies;
+
+SELECT * from areas;
+
+SELECT * from generation_units;
+
+SELECT * from storage_units;
+
+SELECT * from supply_technologies;
+
+SELECT * from transmission_lines;
+
+SELECT * from arcs;
+
+SELECT id, type, json_extract(value, "$.lat") as latitude, json_extract(value, "$.lon") as longitude from supplemental_attributes;
+
+SELECT * from time_series;
+
+SELECT id, time_series_id, datetime(timestamp, 'unixepoch'), value from static_time_series;
+
+SELECT * from deterministic_time_series_view;

--- a/queries.sql
+++ b/queries.sql
@@ -1,21 +1,56 @@
+.print +----------+
+.print | entities |
+.print +----------+
+
 SELECT * from entities;
 
-SELECT * from prime_movers;
+.print +--------------+
+.print | prime movers |
+.print +--------------+
+
+SELECT * from prime_mover_types;
+
+.print +----------------------+
+.print | balancing topologies |
+.print +----------------------+
 
 SELECT * from balancing_topologies;
 
+.print +------------------+
+.print | planning regions |
+.print +------------------+
+
 SELECT * from planning_regions;
+
+.print +------------------+
+.print | generation units |
+.print +------------------+
 
 SELECT * from generation_units;
 
-SELECT id, name, max_capacity, round_trip_efficiency from storage_units;
+.print +---------------+
+.print | storage units |
+.print +---------------+
+SELECT * from storage_units;
 
+.print +---------------------+
+.print | supply technologies |
+.print +---------------------+
 SELECT * from supply_technologies;
 
+.print +--------------------+
+.print | transmission lines |
+.print +--------------------+
 SELECT * from transmission_lines;
 
+.print +------+
+.print | arcs |
+.print +------+
 SELECT * from arcs;
 
+.print +-------------------------+
+.print | Supplemental Attributes |
+.print +-------------------------+
 SELECT
   id,
   type,
@@ -26,6 +61,10 @@ FROM
 WHERE
   type == 'geolocation';
 
+
+.print +-------------+
+.print | Time Series |
+.print +-------------+
 SELECT
   time_series_type,
   name,
@@ -37,6 +76,9 @@ SELECT
 FROM
   time_series;
 
+.print +------------------------------------+
+.print | Deterministic Forecast Time Series |
+.print +------------------------------------+
 SELECT
   id,
   time_series_id,

--- a/schema.sql
+++ b/schema.sql
@@ -78,7 +78,7 @@ CREATE TABLE prime_mover_types (
 CREATE TABLE fuels(
     id integer primary key,
     name text NOT NULL,
-    description text nulll,
+    description text NULL,
     UNIQUE (name)
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -4,42 +4,62 @@
 --      1. Simplicity and ease of use over complexity,
 --      2. Clear, consice and strict fields but allow for extensability,
 --      3. User friendly over peformance, but consider performance always,
-
-
 -- WARNING: This script should only be used while testing the schema and should not
 -- be applied to existing dataset since it drops all the information it has.
-drop table if exists generation_units;
-drop table if exists storage_units;
-drop table if exists prime_movers;
-drop table if exists balancing_topologies;
-drop table if exists supply_technologies;
-drop table if exists storage_technologies;
-drop table if exists transmission_lines;
-drop table if exists demand_requirements;
-drop table if exists planning_regions;
-drop table if exists attributes;
-drop table if exists data_types;
-drop table if exists time_series;
-drop table if exists transmission_interchange;
-drop table if exists entities;
-drop table if exists time_series_associations;
-drop table if exists time_series_metadata;
-drop table if exists single_time_series;
-drop table if exists deterministic_time_series;
-drop table if exists probabilistic_time_series;
-drop table if exists operational_data;
-drop table if exists attributes;
-drop table if exists supplemental_attributes;
-drop table if exists attributes_associations;
+DROP TABLE IF EXISTS generation_units;
+
+DROP TABLE IF EXISTS storage_units;
+
+DROP TABLE IF EXISTS prime_mover_types;
+
+DROP TABLE IF EXISTS balancing_topologies;
+
+DROP TABLE IF EXISTS supply_technologies;
+
+DROP TABLE IF EXISTS storage_technologies;
+
+DROP TABLE IF EXISTS transmission_lines;
+
+DROP TABLE IF EXISTS demand_requirements;
+
+DROP TABLE IF EXISTS planning_regions;
+
+DROP TABLE IF EXISTS attributes;
+
+DROP TABLE IF EXISTS data_types;
+
+DROP TABLE IF EXISTS time_series;
+
+DROP TABLE IF EXISTS transmission_interchanges;
+
+DROP TABLE IF EXISTS entities;
+
+DROP TABLE IF EXISTS time_series_associations;
+
+DROP TABLE IF EXISTS time_series_metadata;
+
+DROP TABLE IF EXISTS single_time_series;
+
+DROP TABLE IF EXISTS deterministic_forecast_time_series;
+
+DROP TABLE IF EXISTS probabilistic_forecast_time_series;
+
+DROP TABLE IF EXISTS operational_data;
+
+DROP TABLE IF EXISTS attributes;
+
+DROP TABLE IF EXISTS supplemental_attributes;
+
+DROP TABLE IF EXISTS attributes_associations;
 
 -- NOTE: This table should not be interacted directly since it gets populated
 -- automatically.
 -- Table of certain entities of griddb schema.
-create table entities (
-  id integer primary key
-  ,entity_type text not null
-  ,entity_id integer not null
-  ,unique (id, entity_id, entity_type)
+CREATE TABLE entities (
+    id integer PRIMARY KEY,
+    entity_type text NOT NULL,
+    entity_id integer NOT NULL,
+    UNIQUE (id, entity_id, entity_type)
 );
 
 -- NOTE: Sienna-griddb follows the convention of the EIA prime mover where we
@@ -48,55 +68,57 @@ create table entities (
 -- their own application. The only constraint is that the uniqueness is enforced
 -- by the combination of (prime_mover, fuel)
 -- Categories to classify generating units and supply technologies
-create table  prime_movers (
-        id integer primary key
-        ,prime_mover text not null
-        ,fuel text null
-        ,description text null
-        ,unique (prime_mover, fuel)
+CREATE TABLE prime_mover_types (
+    id integer primary key,
+    name text NOT NULL,
+    description text NULL,
+    UNIQUE(name)
+);
+
+CREATE TABLE fuels(
+    id integer primary key,
+    name text NOT NULL,
+    description text nulll,
+    UNIQUE (name)
 );
 
 -- Investment regions
-create table planning_regions (
-  id integer primary key
-  ,name text not null unique
-  ,description text null
+CREATE TABLE planning_regions (
+    id integer PRIMARY KEY,
+    name text NOT NULL UNIQUE,
+    description text NULL
 );
 
 -- Balancing topologies for the system. Could be either buses, or larger
 -- aggregated regions.
-create table balancing_topologies (
-  id integer primary key
-  ,name text not null unique
-  ,area text null references planning_regions (name)
-  ,participation_factor real default 1.0 not null check (
-    participation_factor >= 0
-    and participation_factor <= 1
-  )
-  ,description text null
+CREATE TABLE balancing_topologies (
+    id integer PRIMARY KEY,
+    name text NOT NULL UNIQUE,
+    area text NULL REFERENCES planning_regions (name),
+    description text NULL
 );
 
 -- NOTE: The purpose of this table is to provide links different entities that
 -- naturally have a relantionship not model dependent (e.g., transmission lines,
 -- transmission interchanges, etc.).
 -- Physical connection between entities.
-create table arcs (
-  id integer primary key
-  ,from_to int
-  ,to_from int
-  ,foreign key (from_to) references entities (id)
-  ,foreign key (to_from) references entities (id)
+CREATE TABLE arcs (
+    id integer PRIMARY KEY,
+    from_to integer,
+    to_from integer,
+    FOREIGN KEY (from_to) REFERENCES entities (id),
+    FOREIGN KEY (to_from) REFERENCES entities (id)
 );
 
 -- Existing transmission lines
-create table transmission_lines (
-  id integer primary key
-  ,arc_id int
-  ,continuous_rating real not null check (continuous_rating >= 0)
-  ,ste_rating real not null check (ste_rating >= 0)
-  ,lte_rating real not null check (lte_rating >= 0)
-  ,line_length real not null check (line_length >= 0)
-  ,foreign key (arc_id) references arcs (id)
+CREATE TABLE transmission_lines (
+    id integer PRIMARY KEY,
+    arc_id integer,
+    continuous_rating real NOT NULL CHECK (continuous_rating >= 0),
+    ste_rating real NOT NULL CHECK (ste_rating >= 0),
+    lte_rating real NOT NULL CHECK (lte_rating >= 0),
+    line_length real NOT NULL CHECK (line_length >= 0),
+    FOREIGN KEY (arc_id) REFERENCES arcs (id)
 ) strict;
 
 -- NOTE: The purpose of this table is to provide physical limits to flows
@@ -104,88 +126,98 @@ create table transmission_lines (
 -- lines, this entities are used to enforce given physical limits of certain
 -- markets.
 -- Transmission interchanges between two balancing topologies or areas
-create table transmission_interchange (
-        arc_id int references arcs(id)
-        ,max_flow_from real not null
-	,max_flow_to real not null
+CREATE TABLE transmission_interchanges (
+    arc_id int REFERENCES arcs(id),
+    name text NOT NULL,
+    max_flow_from real NOT NULL,
+    max_flow_to real NOT NULL
 ) strict;
 
 -- NOTE: The purpose of this table is to capture data of **existing units only**.
 -- Table of generation units
-create table generation_units (
-   id integer primary key
-  ,name text not null
-  ,prime_mover text not null
-  ,fuel text null
-  ,balancing_topology text not null references balancing_topologies (name)
-  ,start_year integer not null check (start_year >= 0)
-  ,rating real check (rating > 0) default 1.0
-  ,base_power real not null check (base_power > 0)
-  ,foreign key (prime_mover, fuel) references prime_movers (prime_mover, fuel)
-  ,check (base_power >= rating)
-  ,unique (id, name)
+CREATE TABLE generation_units (
+    id integer PRIMARY KEY,
+    name text NOT NULL,
+    prime_mover text NOT NULL REFERENCES prime_mover_types(name),
+    fuel text NULL REFERENCES fuels(name),
+    balancing_topology text NOT NULL REFERENCES balancing_topologies (name),
+    rating real NOT NULL CHECK (rating > 0),
+    base_power real NOT NULL CHECK (base_power > 0),
+    CHECK (base_power >= rating),
+    UNIQUE (name)
 ) strict;
 
 -- NOTE: The purpose of this table is to capture data of **existing storage units only**.
 -- Table of energy storage units (including PHES or other kinds),
-create table storage_units (
-  id integer primary key
-  ,name text not null
-  ,prime_mover text not null
-  ,max_capacity real not null check (max_capacity > 0) -- Energy capacity
-  ,balancing_topology text not null references balancing_topologies (name)
-  ,charging_efficiency real check (
-    charging_efficiency > 0
-    and charging_efficiency <= 1.0
-  ) default 1.0
-  ,discharge_efficiency real check (
-    discharge_efficiency > 0
-    and discharge_efficiency <= 1.0
-  ) default 1.0
-  ,round_trip_efficiency  real generated always as (charging_efficiency * discharge_efficiency) virtual
-  ,start_year integer not null check (start_year >= 0)
-  ,rating real not null default 1 check (rating > 0)
-  ,base_power real not null check (base_power > 0)
-  ,check (base_power >= rating)
-  ,unique(name)
+CREATE TABLE storage_units (
+    id integer PRIMARY KEY,
+    name text NOT NULL,
+    prime_mover text NOT NULL REFERENCES prime_mover_types(name),
+-- Energy capacity
+    max_capacity real NOT NULL CHECK (max_capacity > 0) ,
+    balancing_topology text NOT NULL REFERENCES balancing_topologies (name),
+    efficiency_up real CHECK (
+        efficiency_up > 0
+        AND efficiency_up <= 1.0
+    ) DEFAULT 1.0,
+    efficiency_down real CHECK (
+        efficiency_down > 0
+        AND efficiency_down <= 1.0
+    ) DEFAULT 1.0,
+    rating real NOT NULL DEFAULT 1 CHECK (rating > 0),
+    base_power real NOT NULL CHECK (base_power > 0),
+    CHECK (base_power >= rating),
+    UNIQUE(name)
 ) strict;
+
+CREATE TABLE hydro_reservoir(
+    id integer PRIMARY KEY,
+    name text NOT NULL,
+    UNIQUE(name)
+);
+
+CREATE TABLE hydro_reservoir_connections(
+    turbine_id integer not null REFERENCES generation_units(id),
+    reservoir_id integer not null REFERENCES hydro_reservoir(id)
+);
 
 -- NOTE: The purpose of this table is to capture technologies available for
 -- investment for expansion problems.
 -- Investment technology options for expansion problems
-create table supply_technologies (
-  id integer primary key
-  ,prime_mover text not null
-  ,fuel text null
-  ,area text null references planning_regions (name)
-  ,balancing_topology text null references balancing_topologies (name)
-  ,vom_cost real not null check (vom_cost >= 0)
-  ,fom_cost real not null check (fom_cost >= 0)
-  ,scenario text null
-  ,foreign key (prime_mover, fuel) references prime_movers(prime_mover, fuel)
+CREATE TABLE supply_technologies (
+    id integer PRIMARY KEY,
+    prime_mover text NOT NULL REFERENCES prime_mover_types(name),
+    fuel text NULL REFERENCES  fuels(name),
+    area text NULL REFERENCES planning_regions (name),
+    balancing_topology text NULL REFERENCES balancing_topologies (name),
+    scenario text NULL,
+    UNIQUE(prime_mover, fuel, scenario)
+);
+
+CREATE TABLE transport_technologies(
+    id integer PRIMARY KEY,
+    arc_id integer NULL REFERENCES arcs(id),
+    scenario text NULL,
+    UNIQUE(id, arc_id, scenario)
 );
 
 -- NOTE: The purpose of this table is to link operational parameters to multiple
 -- entities like existing units (real paramters) or supply technologies
 -- (expected parameters).
 -- The same operational data could be attached to multiple entities.
-create table operational_data (
-  id integer primary key
-  ,entity_id integer not null
-  ,fom_cost real not null check (fom_cost >= 0)
-  ,vom_cost real not null check (vom_cost >= 0)
-  ,startup_cost real not null check (startup_cost >= 0)
-  ,min_stable_level real not null check (min_stable_level >= 0)
-  ,mttr integer not null check (mttr >= 0)
-  ,startup_fuel_mmbtu_per_mw real not null check (startup_fuel_mmbtu_per_mw >= 0)
-  ,uptime real not null check (uptime >= 0)
-  ,downtime real not null check (downtime >= 0)
-
-  -- Could overtake some of the fields here.
-  ,operational_cost jsonb null
-
-  -- Enforce unique constraint
-  ,foreign key (entity_id) references entities(id)
+CREATE TABLE operational_data (
+    id integer PRIMARY KEY,
+    entity_id integer NOT NULL,
+    active_power_limit_min real NOT NULL CHECK (active_power_limit_min >= 0),
+    must_run bool,
+    uptime real NOT NULL CHECK (uptime >= 0),
+    downtime real NOT NULL CHECK (downtime >= 0),
+    ramp_up real NOT NULL,
+    ramp_down real NOT NULL,
+    operational_cost jsonb NULL,
+    -- We can add what type of operational cost it is or other parameters (e.g., variable)
+    operational_cost_type text generated always AS (json_type(operational_cost)) virtual,
+    FOREIGN KEY (entity_id) REFERENCES entities(id)
 );
 
 -- NOTE: Attributes are additional parameters that can be linked to entities.
@@ -193,62 +225,63 @@ create table operational_data (
 -- capture on the entity table that should exist on the model. Example of this
 -- fields are variable or fixed operation and maintenance cost or any other
 -- field that its representation is hard to fit into a `integer`, `real` or
--- `texrt`. `It must not be used for operational details since most of the should
+-- `text`. It must not be used for operational details since most of the should
 -- be included in the `operational_data` table.
--- Table with additional (not supplemental) atttributes
-create table attributes (
-  id integer primary key
-  ,type text not null
-  ,name text not null
-  ,value jsonb not null
-  ,json_type text generated always  as (json_type(value)) virtual
+CREATE TABLE attributes (
+    id integer PRIMARY KEY,
+    TYPE text NOT NULL,
+    name text NOT NULL,
+    value jsonb NOT NULL,
+    json_type text generated always AS (json_type(value)) virtual
 );
 
--- association table between attributes and entities
-create table attributes_associations (
-  attribute_id integer not null
-  ,entity_id integer not null
-  ,foreign key (entity_id) references entities (id)
-  ,foreign key (attribute_id) references attributes (id)
-  ,unique(attribute_id, entity_id)
+-- Association table between attributes and entities
+CREATE TABLE attributes_associations (
+    attribute_id integer NOT NULL,
+    entity_id integer NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id),
+    FOREIGN KEY (attribute_id) REFERENCES attributes (id),
+    UNIQUE(attribute_id, entity_id)
 ) strict;
 
--- create supplemental atttributes
-create table supplemental_attributes (
-  id integer primary key
-  ,type text not NULL
-  ,value jsonb not null
-  ,json_type text generated always as (json_type (value)) virtual
+-- NOTE: Supplemental are optional parameters that can be linked to entities.
+-- The main purpose of this is to provide a way to save relevant information
+-- but that could or could not be used for modeling. not `text`. Examples of
+-- this field are geolocation (e.g., lat, long), outages, etc.)
+CREATE TABLE supplemental_attributes (
+    id integer PRIMARY KEY,
+    TYPE text NOT NULL,
+    value jsonb NOT NULL,
+    json_type text generated always AS (json_type (value)) virtual
 );
 
-create table supplemental_attributes_association (
-  attribute_id integer not null
-  ,entity_id integer not null
-  ,foreign key (entity_id) references entities (id)
-  ,foreign key (attribute_id) references supplemental_attributes (id)
+CREATE TABLE supplemental_attributes_association (
+    attribute_id integer NOT NULL,
+    entity_id integer NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id),
+    FOREIGN KEY (attribute_id) REFERENCES supplemental_attributes (id)
 ) strict;
 
-create table time_series (
-  id integer primary key
-  ,uuid text null
-  ,time_series_type text not null
-  ,name text not null
-  ,initial_timestamp datetime not NULL
-  ,resolution_ms integer not NULL
-  ,horizon integer not null
-  ,interval integer not null
-  ,length integer not null
-  ,features jsonb null
-  ,metadata jsonb null
+CREATE TABLE time_series (
+    id integer PRIMARY KEY,
+    uuid text NULL,
+    time_series_type text NOT NULL,
+    name text NOT NULL,
+    initial_timestamp datetime NOT NULL,
+    resolution_ms integer NOT NULL,
+    horizon integer NOT NULL,
+    INTERVAL integer NOT NULL,
+    length integer NOT NULL,
+    features jsonb NULL,
+    metadata jsonb NULL
 );
 
 -- associate time series with entities or attributes
-create table time_series_associations (
-  id integer primary key
-  ,time_series_id integer not null
-  ,owner_id integer not NULL
-  ,foreign key (owner_id) references entities (id)
-  ,foreign key (time_series_id) references time_series (id)
+CREATE TABLE time_series_associations (
+    time_series_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    FOREIGN KEY (owner_id) REFERENCES entities (id),
+    FOREIGN KEY (time_series_id) REFERENCES time_series (id)
 ) strict;
 
 -- From Sienna docs:
@@ -256,117 +289,40 @@ create table time_series_associations (
 -- a single value assigned to a component field, such as its maximum active power.
 -- This data commonly is obtained from historical information or the realization
 -- of a time-varying quantity.
-create table static_time_series (
-  id integer primary key
-  ,time_series_id integer not null
-  ,uuid text null
-  ,timestamp datetime not null
-  ,value real not null
-  ,foreign key (time_series_id) references time_series (id)
+CREATE TABLE static_time_series (
+    id integer PRIMARY KEY,
+    time_series_id integer NOT NULL,
+    uuid text NULL,
+    timestamp datetime NOT NULL,
+    value real NOT NULL,
+    FOREIGN KEY (time_series_id) REFERENCES time_series (id)
 );
 
 --  A deterministic time series represent forecast that data that usually comes
 --  in the following format, where a column represents the time stamp
 --  associated with the initial time of the forecast, and the remaining columns
 --  represent the forecasted values at each step in the forecast horizon.
-create table deterministic_time_series (
-  id integer primary key
-  ,time_series_id integer not null
-  ,uuid text null
-  ,timestamp datetime not null
-  ,value jsonb not null
-  ,foreign key (time_series_id) references time_series (id)
+CREATE TABLE deterministic_forecast_time_series (
+    id integer PRIMARY KEY,
+    time_series_id integer NOT NULL,
+    uuid text NULL,
+    timestamp datetime NOT NULL,
+    value jsonb NOT NULL,
+    FOREIGN KEY (time_series_id) REFERENCES time_series (id)
 );
 
-create table probabilistic_time_series (
-  id integer primary key
-  ,time_series_id integer not null
-  ,uuid text null
-  ,timestamp datetime not null
-  ,value real not null
-  ,foreign key (time_series_id) references time_series (id)
+CREATE TABLE probabilistic_forecast_time_series (
+    id integer PRIMARY KEY,
+    time_series_id integer NOT NULL,
+    uuid text NULL,
+    timestamp datetime NOT NULL,
+    value real NOT NULL,
+    FOREIGN KEY (time_series_id) REFERENCES time_series (id)
 );
-
--- View sections
-CREATE VIEW deterministic_time_series_view AS
-WITH json_data AS (
-  SELECT
-    deterministic_time_series.time_series_id
-    ,deterministic_time_series.id
-    ,deterministic_time_series.timestamp
-    ,json_each.value
-    ,ROW_NUMBER() OVER (PARTITION BY deterministic_time_series.id ORDER BY json_each.value) AS horizon
-  FROM deterministic_time_series, json_each(deterministic_time_series.value)
-)
-SELECT time_series_id, id, timestamp, horizon, value
-FROM json_data;
-
-
--- Trigger section
-CREATE TRIGGER IF not EXISTS autofill_supply
-AFTER INSERT ON supply_technologies
-BEGIN
-    INSERT INTO entities(entity_type, entity_id) VALUES("supply_technologies", new.id);
-END;
-
-CREATE TRIGGER IF not EXISTS autofill_generation_units
-AFTER INSERT ON generation_units
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("generation_units", new.id);
-END;
-
-CREATE TRIGGER IF not EXISTS autofill_storage_units
-AFTER INSERT ON storage_units
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("storage_units", new.id);
-END;
-
-CREATE TRIGGER IF not EXISTS autofill_areas
-AFTER INSERT ON planning_regions
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("planning_regions", new.id);
-END;
-
-CREATE TRIGGER IF not EXISTS autofill_topologies
-AFTER INSERT ON balancing_topologies
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("balancing_topologies", new.id);
-END;
-
-CREATE TRIGGER IF not EXISTS autofill_attributes
-AFTER INSERT ON supplemental_attributes
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("supplemental_attributes", new.id);
-END;
-
-CREATE TRIGGER IF not EXISTS autofill_attributes
-AFTER INSERT ON attributes
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("attribute", new.id);
-END;
-
--- Create a trigger that runs after inserting into the arcs table
-CREATE TRIGGER enforce_arc_entity_types_insert
-AFTER INSERT ON arcs
-BEGIN
-    -- Check if the from_to entity has a valid type
-    SELECT CASE
-        WHEN (SELECT entity_type FROM entities WHERE id = NEW.from_to)
-             NOT IN ('balancing_topologies', 'planning_regions')
-        THEN RAISE(ABORT, 'Invalid from_to entity type')
-    END;
-
-    -- Check if the to_from entity has a valid type
-    SELECT CASE
-        WHEN (SELECT entity_type FROM entities WHERE id = NEW.to_from)
-             NOT IN ('balancing_topologies', 'planning_regions')
-        THEN RAISE(ABORT, 'Invalid to_from entity type')
-    END;
-END;
 
 -- Safety mechanism to force json arrays
 -- CREATE TRIGGER enforce_json_array_value_on_deterministic_time_series
--- BEFORE INSERT ON deterministic_time_series
+-- BEFORE INSERT ON deterministic_forecast_time_series
 -- FOR EACH ROW
 -- WHEN NOT (json_valid(NEW.value) AND json_type(NEW.value, '$') = 'array')
 -- BEGIN

--- a/schema.sql
+++ b/schema.sql
@@ -1,11 +1,13 @@
 -- DISCLAIMER
 -- The current version of this schema only works for SQLITE >=3.45
--- Some design choices we made:
+-- When adding new functionality, think about the following:
 --      1. Simplicity and ease of use over complexity,
---      2. Clear, consice and strict fields but allow for extensability throught supplemental_attributes,
---      3. User friendly over peformance,
+--      2. Clear, consice and strict fields but allow for extensability,
+--      3. User friendly over peformance, but consider performance always,
 
--- drop tables if they exist
+
+-- WARNING: This script should only be used while testing the schema and should not
+-- be applied to existing dataset since it drops all the information it has.
 drop table if exists generation_units;
 drop table if exists storage_units;
 drop table if exists prime_movers;
@@ -14,7 +16,7 @@ drop table if exists supply_technologies;
 drop table if exists storage_technologies;
 drop table if exists transmission_lines;
 drop table if exists demand_requirements;
-drop table if exists areas;
+drop table if exists planning_regions;
 drop table if exists attributes;
 drop table if exists data_types;
 drop table if exists time_series;
@@ -26,19 +28,90 @@ drop table if exists single_time_series;
 drop table if exists deterministic_time_series;
 drop table if exists probabilistic_time_series;
 drop table if exists operational_data;
+drop table if exists attributes;
 drop table if exists supplemental_attributes;
 drop table if exists attributes_associations;
 
--- Table of entities gets populated automatically once there is an insert on the core tables.
--- NOTE: This table should not be interacted directly
-create table entities(
-        id integer primary key
-        ,entity_type text not null
-        ,entity_id integer not null
-        ,unique (id, entity_id, entity_type)
+-- NOTE: This table should not be interacted directly since it gets populated
+-- automatically.
+-- Table of certain entities of griddb schema.
+create table entities (
+  id integer primary key
+  ,entity_type text not null
+  ,entity_id integer not null
+  ,unique (id, entity_id, entity_type)
 );
 
--- Table of generation units (aka, existing units).
+-- NOTE: Sienna-griddb follows the convention of the EIA prime mover where we
+-- have a `prime_mover` and `fuel` to classify generators/storage units.
+-- However, users could use any combination of `prime_mover` and `fuel` for
+-- their own application. The only constraint is that the uniqueness is enforced
+-- by the combination of (prime_mover, fuel)
+-- Categories to classify generating units and supply technologies
+create table  prime_movers (
+        id integer primary key
+        ,prime_mover text not null
+        ,fuel text null
+        ,description text null
+        ,unique (prime_mover, fuel)
+);
+
+-- Investment regions
+create table planning_regions (
+  id integer primary key
+  ,name text not null unique
+  ,description text null
+);
+
+-- Balancing topologies for the system. Could be either buses, or larger
+-- aggregated regions.
+create table balancing_topologies (
+  id integer primary key
+  ,name text not null unique
+  ,area text null references planning_regions (name)
+  ,participation_factor real default 1.0 not null check (
+    participation_factor >= 0
+    and participation_factor <= 1
+  )
+  ,description text null
+);
+
+-- NOTE: The purpose of this table is to provide links different entities that
+-- naturally have a relantionship not model dependent (e.g., transmission lines,
+-- transmission interchanges, etc.).
+-- Physical connection between entities.
+create table arcs (
+  id integer primary key
+  ,from_to int
+  ,to_from int
+  ,foreign key (from_to) references entities (id)
+  ,foreign key (to_from) references entities (id)
+);
+
+-- Existing transmission lines
+create table transmission_lines (
+  id integer primary key
+  ,arc_id int
+  ,continuous_rating real not null check (continuous_rating >= 0)
+  ,ste_rating real not null check (ste_rating >= 0)
+  ,lte_rating real not null check (lte_rating >= 0)
+  ,line_length real not null check (line_length >= 0)
+  ,foreign key (arc_id) references arcs (id)
+) strict;
+
+-- NOTE: The purpose of this table is to provide physical limits to flows
+-- between areas or balancing topologies. In contrast with the transmission
+-- lines, this entities are used to enforce given physical limits of certain
+-- markets.
+-- Transmission interchanges between two balancing topologies or areas
+create table transmission_interchange (
+        arc_id int references arcs(id)
+        ,max_flow_from real not null
+	,max_flow_to real not null
+) strict;
+
+-- NOTE: The purpose of this table is to capture data of **existing units only**.
+-- Table of generation units
 create table generation_units (
    id integer primary key
   ,name text not null
@@ -48,12 +121,13 @@ create table generation_units (
   ,start_year integer not null check (start_year >= 0)
   ,rating real check (rating > 0) default 1.0
   ,base_power real not null check (base_power > 0)
-  ,check (base_power >= rating)
   ,foreign key (prime_mover, fuel) references prime_movers (prime_mover, fuel)
+  ,check (base_power >= rating)
   ,unique (id, name)
 ) strict;
 
--- Table of energy storage units.
+-- NOTE: The purpose of this table is to capture data of **existing storage units only**.
+-- Table of energy storage units (including PHES or other kinds),
 create table storage_units (
   id integer primary key
   ,name text not null
@@ -76,12 +150,14 @@ create table storage_units (
   ,unique(name)
 ) strict;
 
--- Investment technology options
+-- NOTE: The purpose of this table is to capture technologies available for
+-- investment for expansion problems.
+-- Investment technology options for expansion problems
 create table supply_technologies (
   id integer primary key
   ,prime_mover text not null
   ,fuel text null
-  ,area text null references areas (name)
+  ,area text null references planning_regions (name)
   ,balancing_topology text null references balancing_topologies (name)
   ,vom_cost real not null check (vom_cost >= 0)
   ,fom_cost real not null check (fom_cost >= 0)
@@ -89,7 +165,9 @@ create table supply_technologies (
   ,foreign key (prime_mover, fuel) references prime_movers(prime_mover, fuel)
 );
 
--- Operational data that could be attach to supply technologies or existing units.
+-- NOTE: The purpose of this table is to link operational parameters to multiple
+-- entities like existing units (real paramters) or supply technologies
+-- (expected parameters).
 -- The same operational data could be attached to multiple entities.
 create table operational_data (
   id integer primary key
@@ -110,95 +188,67 @@ create table operational_data (
   ,foreign key (entity_id) references entities(id)
 );
 
--- create table for prime movers
-create table  prime_movers (
-        id integer primary key
-        ,prime_mover text not null
-        ,fuel text null
-        ,description text null
-        ,unique (prime_mover, fuel)
+-- NOTE: Attributes are additional parameters that can be linked to entities.
+-- The main purpose of this is when there is an important field that is not
+-- capture on the entity table that should exist on the model. Example of this
+-- fields are variable or fixed operation and maintenance cost or any other
+-- field that its representation is hard to fit into a `integer`, `real` or
+-- `texrt`. `It must not be used for operational details since most of the should
+-- be included in the `operational_data` table.
+-- Table with additional (not supplemental) atttributes
+create table attributes (
+  id integer primary key
+  ,type text not null
+  ,name text not null
+  ,value jsonb not null
+  ,json_type text generated always  as (json_type(value)) virtual
 );
 
--- create table for balancing topologies
-create table balancing_topologies (
-        id integer primary key
-	,name text not null unique
-	,area text null references areas(name)
-	,participation_factor real default 1.0 not null check (participation_factor >= 0 and participation_factor <= 1)
-	,description text null
-);
-
--- change to planning regions
-create table  areas (
-        id integer primary key
-	,name text not null unique
-	,description text null
-);
-
--- physical connection between entities
-create table arcs(
-        id integer primary key
-        ,from_to int
-        ,to_from int
-        ,foreign key (from_to) references entities(id)
-        ,foreign key (to_from) references entities(id)
-);
-
--- transmission lines
-create table transmission_lines (
-        id integer primary key
-        ,arc_id int
-	,continuous_rating real not null check(continuous_rating >= 0)
-	,ste_rating real not null check (ste_rating >=0)
-	,lte_rating real not null check (lte_rating >=0)
-	,line_length real not null check (line_length >= 0)
-        ,foreign key (arc_id) references arcs(id)
-) strict;
-
-
--- flow between two regions
-create table transmission_interchange (
-        arc_id int references arcs(id)
-        ,max_flow_from real not null
-	,max_flow_to real not null
+-- association table between attributes and entities
+create table attributes_associations (
+  attribute_id integer not null
+  ,entity_id integer not null
+  ,foreign key (entity_id) references entities (id)
+  ,foreign key (attribute_id) references attributes (id)
+  ,unique(attribute_id, entity_id)
 ) strict;
 
 -- create supplemental atttributes
 create table supplemental_attributes (
-	id integer primary key
-        ,type text not null
-	,value jsonb not null
+  id integer primary key
+  ,type text not NULL
+  ,value jsonb not null
+  ,json_type text generated always as (json_type (value)) virtual
 );
 
--- association table between attributes and entities
-create table attributes_associations(
-	attribute_id integer not null
-	,entity_id integer not null
-	,foreign key (entity_id) references entities(id)
-	,foreign key (attribute_id) references supplemental_attributes(id)
+create table supplemental_attributes_association (
+  attribute_id integer not null
+  ,entity_id integer not null
+  ,foreign key (entity_id) references entities (id)
+  ,foreign key (attribute_id) references supplemental_attributes (id)
 ) strict;
 
-create table time_series(
-        id integer primary key
-        ,uuid text null
-        ,time_series_type text not null
-        ,name text not null
-        ,initial_timestamp datetime not NULL
-        ,resolution_ms integer not NULL
-        ,horizon integer not null
-        ,interval integer not null
-        ,length integer not null
-        ,features jsonb null
-        ,metadata jsonb null
+create table time_series (
+  id integer primary key
+  ,uuid text null
+  ,time_series_type text not null
+  ,name text not null
+  ,initial_timestamp datetime not NULL
+  ,resolution_ms integer not NULL
+  ,horizon integer not null
+  ,interval integer not null
+  ,length integer not null
+  ,features jsonb null
+  ,metadata jsonb null
 );
 
 -- associate time series with entities or attributes
-create table time_series_associations(
-        id integer primary key
-        ,time_series_id integer not null
-        ,owner_id integer not NULL
-        ,foreign key (owner_id) references entities(id)
-        ,foreign key (time_series_id) references time_series(id)
+create table time_series_associations (
+  id integer primary key
+  ,time_series_id integer not null
+  ,owner_id integer not NULL
+  ,foreign key (owner_id) references entities (id)
+  ,foreign key (time_series_id) references time_series (id)
 ) strict;
 
 -- From Sienna docs:
@@ -206,35 +256,35 @@ create table time_series_associations(
 -- a single value assigned to a component field, such as its maximum active power.
 -- This data commonly is obtained from historical information or the realization
 -- of a time-varying quantity.
-create table static_time_series(
-        id integer primary key
-        ,time_series_id datetime not null
-        ,uuid text null
-        ,timestamp datetime not null
-        ,value real not null
-        ,foreign key (time_series_id) references time_series(id)
+create table static_time_series (
+  id integer primary key
+  ,time_series_id datetime not null
+  ,uuid text null
+  ,timestamp datetime not null
+  ,value real not null
+  ,foreign key (time_series_id) references time_series (id)
 );
 
 --  A deterministic time series represent forecast that data that usually comes
 --  in the following format, where a column represents the time stamp
 --  associated with the initial time of the forecast, and the remaining columns
 --  represent the forecasted values at each step in the forecast horizon.
-create table deterministic_time_series(
-        id integer primary key
-        ,time_series_id integer not null
-        ,uuid text null
-        ,timestamp datetime not null
-        ,value jsonb not null
-        ,foreign key (time_series_id) references time_series(id)
+create table deterministic_time_series (
+  id integer primary key
+  ,time_series_id integer not null
+  ,uuid text null
+  ,timestamp datetime not null
+  ,value jsonb not null
+  ,foreign key (time_series_id) references time_series (id)
 );
 
-create table probabilistic_time_series(
-        id integer primary key
-        ,time_series_id integer not null
-        ,uuid text null
-        ,timestamp datetime not null
-        ,value real not null
-        ,foreign key (time_series_id) references time_series(id)
+create table probabilistic_time_series (
+  id integer primary key
+  ,time_series_id integer not null
+  ,uuid text null
+  ,timestamp datetime not null
+  ,value real not null
+  ,foreign key (time_series_id) references time_series (id)
 );
 
 -- View sections
@@ -272,9 +322,9 @@ BEGIN
 END;
 
 CREATE TRIGGER IF not EXISTS autofill_areas
-AFTER INSERT ON areas
+AFTER INSERT ON planning_regions
 BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("areas", new.id);
+	INSERT INTO entities(entity_type, entity_id) VALUES("planning_regions", new.id);
 END;
 
 CREATE TRIGGER IF not EXISTS autofill_topologies
@@ -289,6 +339,12 @@ BEGIN
 	INSERT INTO entities(entity_type, entity_id) VALUES("supplemental_attributes", new.id);
 END;
 
+CREATE TRIGGER IF not EXISTS autofill_attributes
+AFTER INSERT ON attributes
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("attribute", new.id);
+END;
+
 -- Create a trigger that runs after inserting into the arcs table
 CREATE TRIGGER enforce_arc_entity_types_insert
 AFTER INSERT ON arcs
@@ -296,14 +352,14 @@ BEGIN
     -- Check if the from_to entity has a valid type
     SELECT CASE
         WHEN (SELECT entity_type FROM entities WHERE id = NEW.from_to)
-             NOT IN ('balancing_topologies', 'areas')
+             NOT IN ('balancing_topologies', 'planning_regions')
         THEN RAISE(ABORT, 'Invalid from_to entity type')
     END;
 
     -- Check if the to_from entity has a valid type
     SELECT CASE
         WHEN (SELECT entity_type FROM entities WHERE id = NEW.to_from)
-             NOT IN ('balancing_topologies', 'areas')
+             NOT IN ('balancing_topologies', 'planning_regions')
         THEN RAISE(ABORT, 'Invalid to_from entity type')
     END;
 END;

--- a/schema.sql
+++ b/schema.sql
@@ -52,6 +52,21 @@ DROP TABLE IF EXISTS supplemental_attributes;
 
 DROP TABLE IF EXISTS attributes_associations;
 
+DROP TABLE IF EXISTS arcs;
+
+DROP TABLE IF EXISTS hydro_reservoir;
+
+DROP TABLE IF EXISTS hydro_reservoir_connections;
+
+DROP TABLE IF EXISTS fuels;
+
+DROP TABLE IF EXISTS supplemental_attributes_association;
+
+DROP TABLE IF EXISTS transport_technologies;
+
+DROP TABLE IF EXISTS static_time_series;
+
+
 -- NOTE: This table should not be interacted directly since it gets populated
 -- automatically.
 -- Table of certain entities of griddb schema.
@@ -127,6 +142,7 @@ CREATE TABLE transmission_lines (
 -- markets.
 -- Transmission interchanges between two balancing topologies or areas
 CREATE TABLE transmission_interchanges (
+    id integer PRIMARY KEY,
     arc_id int REFERENCES arcs(id),
     name text NOT NULL,
     max_flow_from real NOT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -260,7 +260,7 @@ create table static_time_series (
   id integer primary key
   ,time_series_id integer not null
   ,uuid text null
-  ,timestamp integer not null
+  ,timestamp datetime not null
   ,value real not null
   ,foreign key (time_series_id) references time_series (id)
 );

--- a/schema.sql
+++ b/schema.sql
@@ -1,9 +1,14 @@
+-- DISCLAIMER
+-- The current version of this schema only works for SQLITE >=3.45
+-- Some design choices we made:
+--      1. Simplicity and ease of use over complexity,
+--      2. Clear, consice and strict fields but allow for extensability throught supplemental_attributes,
+--      3. User friendly over peformance,
+
 -- drop tables if they exist
 drop table if exists generation_units;
 drop table if exists storage_units;
-drop view if exists unit_attributes;
-drop view if exists unit_time_series;
-drop table if exists prime_mover_types;
+drop table if exists prime_movers;
 drop table if exists balancing_topologies;
 drop table if exists supply_technologies;
 drop table if exists storage_technologies;
@@ -13,258 +18,301 @@ drop table if exists areas;
 drop table if exists attributes;
 drop table if exists data_types;
 drop table if exists time_series;
-drop table if exists piecewise_linear;
 drop table if exists transmission_interchange;
 drop table if exists entities;
-drop table if exists linkages;
-drop table if exists reserves;
+drop table if exists time_series_associations;
+drop table if exists time_series_metadata;
+drop table if exists single_time_series;
+drop table if exists deterministic_time_series;
+drop table if exists probabilistic_time_series;
 drop table if exists operational_data;
+drop table if exists supplemental_attributes;
+drop table if exists attributes_associations;
 
--- only generation units
-create table  generation_units (
-	unit_id integer primary key,
-	name text not null unique,
-	prime_mover text not null,
-	fuel_type text not null,
-	balancing_topology text not null references balancing_topologies(name),
-	start_year integer not null check (start_year >= 0),
-	rating float not null check (rating > 0 ),
-	base_power float not null check (base_power > 0),
-	check (base_power >= rating),
-	foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
+-- Table of entities gets populated automatically once there is an insert on the core tables.
+-- NOTE: This table should not be interacted directly
+create table entities(
+        id integer primary key
+        ,entity_type text not null
+        ,entity_id integer not null
+        ,unique (id, entity_id, entity_type)
 );
 
--- only storge units
-create table  storage_units (
-	storage_unit_id integer primary key,
-	name text not null unique,
-	prime_mover text not null,
-	fuel_type text not null,
-	max_capacity float not null check (max_capacity > 0),
-	round_trip_efficiency float check (round_trip_efficiency >= 0),
-	balancing_topology text not null references balancing_topologies(name),
-	charging_efficiency float not null check (charging_efficiency > 0),
-	discharge_efficiency float not null check (discharge_efficiency > 0),
-	start_year integer not null check (start_year >= 0),
-	rating float not null default 1 check (rating > 0 ),
-	base_power float not null check (base_power > 0),
-	scenario text null,
-	check (base_power >= rating),
-	foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
-);
+-- Table of generation units (aka, existing units).
+create table generation_units (
+   id integer primary key
+  ,name text not null
+  ,prime_mover text not null
+  ,fuel text null
+  ,balancing_topology text not null references balancing_topologies (name)
+  ,start_year integer not null check (start_year >= 0)
+  ,rating real check (rating > 0) default 1.0
+  ,base_power real not null check (base_power > 0)
+  ,check (base_power >= rating)
+  ,foreign key (prime_mover, fuel) references prime_movers (prime_mover, fuel)
+  ,unique (id, name)
+) strict;
 
--- create table for technologies, perhaps change the name to investment_technologies
+-- Table of energy storage units.
+create table storage_units (
+  id integer primary key
+  ,name text not null
+  ,prime_mover text not null
+  ,max_capacity real not null check (max_capacity > 0) -- Energy capacity
+  ,balancing_topology text not null references balancing_topologies (name)
+  ,charging_efficiency real check (
+    charging_efficiency > 0
+    and charging_efficiency <= 1.0
+  ) default 1.0
+  ,discharge_efficiency real check (
+    discharge_efficiency > 0
+    and discharge_efficiency <= 1.0
+  ) default 1.0
+  ,round_trip_efficiency  real generated always as (charging_efficiency * discharge_efficiency) virtual
+  ,start_year integer not null check (start_year >= 0)
+  ,rating real not null default 1 check (rating > 0)
+  ,base_power real not null check (base_power > 0)
+  ,check (base_power >= rating)
+  ,unique(name)
+) strict;
+
+-- Investment technology options
 create table supply_technologies (
-    technology_id integer primary key,
-    prime_mover text not null,
-	  fuel_type text not null,
-	  technology_class real null,
-    vom_cost float not null check (vom_cost >= 0),
-    fom_cost float not null check (fom_cost >= 0),
-    scenario text null,
-	  area text null references areas(name),
-	  balancing_topology text null references balancing_topologies(name),
-	  foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
+  id integer primary key
+  ,prime_mover text not null
+  ,fuel text null
+  ,area text null references areas (name)
+  ,balancing_topology text null references balancing_topologies (name)
+  ,vom_cost real not null check (vom_cost >= 0)
+  ,fom_cost real not null check (fom_cost >= 0)
+  ,scenario text null
+  ,foreign key (prime_mover, fuel) references prime_movers(prime_mover, fuel)
 );
 
-create table storage_technologies (
-	storage_unit_id integer primary key,
-	name text not null unique,
-	prime_mover text not null,
-	fuel_type text not null,
-	scenario text null,
-	area text null references areas(name),
-	balancing_topology text null references balancing_topologies(name),
-	foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
-);
-
-
+-- Operational data that could be attach to supply technologies or existing units.
+-- The same operational data could be attached to multiple entities.
 create table operational_data (
-	unit_id references generation_units(unit_id),
-	fom_cost float not null check (fom_cost >= 0),
-	vom_cost float not null check (vom_cost >=0),
-	forced_outage float not null,
-	startup_cost float not null check (startup_cost >= 0),
-	min_stable_level float not null check (min_stable_level >= 0),
-	mttr integer not null check (mttr >= 0),
-	startup_fuel_mmbtu_per_mw float not null check (startup_fuel_mmbtu_per_mw >= 0),
-	uptime float not null check (uptime >= 0),
-	downtime float not null check (downtime >= 0)
+  id integer primary key
+  ,entity_id integer not null
+  ,fom_cost real not null check (fom_cost >= 0)
+  ,vom_cost real not null check (vom_cost >= 0)
+  ,startup_cost real not null check (startup_cost >= 0)
+  ,min_stable_level real not null check (min_stable_level >= 0)
+  ,mttr integer not null check (mttr >= 0)
+  ,startup_fuel_mmbtu_per_mw real not null check (startup_fuel_mmbtu_per_mw >= 0)
+  ,uptime real not null check (uptime >= 0)
+  ,downtime real not null check (downtime >= 0)
+
+  -- Could overtake some of the fields here.
+  ,operational_cost jsonb null
+
+  -- Enforce unique constraint
+  ,foreign key (entity_id) references entities(id)
 );
 
 -- create table for prime movers
-create table  prime_mover_types (
-	prime_mover text not null,
-	fuel_type text not null,
-	description text null,
-	primary key (prime_mover, fuel_type)
+create table  prime_movers (
+        id integer primary key
+        ,prime_mover text not null
+        ,fuel text null
+        ,description text null
+        ,unique (prime_mover, fuel)
 );
 
 -- create table for balancing topologies
 create table balancing_topologies (
-	name text not null primary key,
-	area text null references areas(name),
-	participation_factor float default 1.0 not null check (participation_factor >= 0 and participation_factor <= 1),
-	description text null
+        id integer primary key
+	,name text not null unique
+	,area text null references areas(name)
+	,participation_factor real default 1.0 not null check (participation_factor >= 0 and participation_factor <= 1)
+	,description text null
 );
 
 -- change to planning regions
 create table  areas (
-	name text not null primary key,
-	description text null
+        id integer primary key
+	,name text not null unique
+	,description text null
 );
 
--- electrical information of the lines
-create table  transmission_lines (
-	balancing_topology_from text references balancing_topologies(name),
-	balancing_topology_to text references balancing_topologies(name),
-	area_from text references areas(name),
-	area_to text references areas(name),
-	continuous_rating float not null check(continuous_rating >= 0),
-	ste_rating float not null check (ste_rating >=0),
-	lte_rating float not null check (lte_rating >=0),
-	line_length float not null check (line_length >= 0)
+-- physical connection between entities
+create table arcs(
+        id integer primary key
+        ,from_to int
+        ,to_from int
+        ,foreign key (from_to) references entities(id)
+        ,foreign key (to_from) references entities(id)
 );
 
+-- transmission lines
+create table transmission_lines (
+        id integer primary key
+        ,arc_id int
+	,continuous_rating real not null check(continuous_rating >= 0)
+	,ste_rating real not null check (ste_rating >=0)
+	,lte_rating real not null check (lte_rating >=0)
+	,line_length real not null check (line_length >= 0)
+        ,foreign key (arc_id) references arcs(id)
+) strict;
 
--- ) strict;
+
 -- flow between two regions
-create table  transmission_interchange (
-	area_from text not null references areas(name),
-	area_to text not null references areas(name),
-	max_flow_from float not null,
-	max_flow_to float not null
+create table transmission_interchange (
+        arc_id int references arcs(id)
+        ,max_flow_from real not null
+	,max_flow_to real not null
+) strict;
+
+-- create supplemental atttributes
+create table supplemental_attributes (
+	id integer primary key
+        ,type text not null
+	,value jsonb not null
 );
 
--- create load input table, at some point need to add the growth rate
-create table  demand_requirements (
-	entity_attribute_id integer primary key,
-	peak_load float not null,
-	area text references areas(name),
-	balancing_topology text references balancing_topologies(name)
-);
-
--- create entity-attribute table
-create table attributes (
-	entity_attribute_id integer primary key,
-	entity_id integer not null,
-	entity_type text not null,
-	name text not null,
-	value any null,
-	data_type text not null references data_types(name),
-	foreign key (entity_type) references table_names(name),
-    check (name != 'entity_id')
-);
-
-create table data_types(
-	name text not null primary key,
-	validation_query text,
-	description text null
-);
-
-create table reserves(
-    id integer primary key,
-    time_frame float not null,
-    requirement float not null,
-    direction text not null
-);
-
--- Entities gets populated automatically once there is an insert on the core tables.
-create table entities(
-	id integer primary key,
-	entity_type text not null references table_names(name),
-	entity_id integer not null
-);
-
-
-
-CREATE TRIGGER IF NOT EXISTS autofill_supply
-AFTER INSERT ON supply_technologies
-BEGIN
-    INSERT INTO entities(entity_type, entity_id) VALUES("supply_technologies", new.technology_id);
-END;
-
-CREATE TRIGGER IF NOT EXISTS autofill_generation_units
-AFTER INSERT ON generation_units
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("generation_units", new.unit_id);
-END;
-
-CREATE TRIGGER IF NOT EXISTS autofill_storage_units
-AFTER INSERT ON storage_units
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("storage_units", new.storage_unit_id);
-END;
-
-CREATE TRIGGER IF NOT EXISTS autofill_storage_technologies
-AFTER INSERT ON storage_technologies
-BEGIN
-	INSERT INTO entities(entity_type, entity_id) VALUES("storage_technologies", new.storage_unit_id);
-END;
-
-CREATE TRIGGER IF NOT EXISTS autofill_reserves
-AFTER INSERT ON reserves
-BEGIN
-    INSERT INTO entities(entity_type, entity_id) VALUES("reserves", new.id);
-END;
-
--- Create function data table
-
-insert into data_types (name, validation_query) values
-('integer', 'cast(? as integer) is not null'),
-('float', 'cast(? as float) is not null'),
-('real', 'cast(? as real) is not null'),
-('text', 'cast(? as text) is not null'),
-('json', 'json_valid(?) is 1');
-('time_series', '? is null'),
-('piecewise_linear', '? is null');
--- Create a new data type for function data here
-
--- triggers
--- we might need a better way of doing this. but we can not get more information where
--- it failed.
-create trigger validate_attribute_data_type
-before insert on attributes
-for each row  -- noqa: PRS
-begin
-    select case
-        when new.data_type = 'integer' and typeof(new.value) != 'integer' then
-            raise(fail, 'invalid data type for attribute value. expected integer.')  -- noqa: PRS
-        when new.data_type = 'text' and typeof(new.value) != 'text' then
-            raise(fail, 'invalid data type for attribute value. expected text.')  -- noqa: PRS
-		when new.data_type = 'float' and typeof(new.value) != 'float' then
-			raise(fail, 'invalid data type for attribute value. expected float.')  -- noqa: PRS
-		when new.data_type = 'json' and json_valid(new.value) != 1 then
-            raise(fail, 'invalid data type for attribute value. expected valid JSON.') -- noqa: PRS
-    -- add more conditions for other data types as needed
-    end;
-end;
-
+-- association table between attributes and entities
+create table attributes_associations(
+	attribute_id integer not null
+	,entity_id integer not null
+	,foreign key (entity_id) references entities(id)
+	,foreign key (attribute_id) references supplemental_attributes(id)
+) strict;
 
 create table time_series(
-	entity_id integer references entities(id),
-	timestamp not null,
-	value float not null
+        id integer primary key
+        ,uuid text null
+        ,time_series_type text not null
+        ,name text not null
+        ,initial_timestamp datetime not NULL
+        ,resolution_ms integer not NULL
+        ,horizon integer not null
+        ,interval integer not null
+        ,length integer not null
+        ,features jsonb null
+        ,metadata jsonb null
 );
 
-create view unit_attributes as
-select u.unit_id,
-       u.name,
-       u.prime_mover,
-       u.balancing_topology,
-       u.rating,
-       ea.name as attribute_name,
-       ea.value as attribute_value,
-       ea.data_type as attribute_type
-from generation_units u
-left join attributes ea on u.unit_id = ea.entity_id and ea.entity_type = 'generation_units';
+-- associate time series with entities or attributes
+create table time_series_associations(
+        id integer primary key
+        ,time_series_id integer not null
+        ,owner_id integer not NULL
+        ,foreign key (owner_id) references entities(id)
+        ,foreign key (time_series_id) references time_series(id)
+) strict;
 
-create view unit_time_series as
-select u.name as unit_name,
-       a.name,
-       ts.timestamp,
-       ts.value
-from generation_units u
-join attributes a on u.unit_id = a.entity_id
-join time_series ts on a.entity_attribute_id = ts.entity_attribute_id
-where a.entity_type = 'generation_units' and a.data_type = "time_series";
+-- From Sienna docs:
+-- A static time series data is a single column of data where each time period has
+-- a single value assigned to a component field, such as its maximum active power.
+-- This data commonly is obtained from historical information or the realization
+-- of a time-varying quantity.
+create table static_time_series(
+        id integer primary key
+        ,time_series_id datetime not null
+        ,uuid text null
+        ,timestamp datetime not null
+        ,value real not null
+        ,foreign key (time_series_id) references time_series(id)
+);
+
+--  A deterministic time series represent forecast that data that usually comes
+--  in the following format, where a column represents the time stamp
+--  associated with the initial time of the forecast, and the remaining columns
+--  represent the forecasted values at each step in the forecast horizon.
+create table deterministic_time_series(
+        id integer primary key
+        ,time_series_id integer not null
+        ,uuid text null
+        ,timestamp datetime not null
+        ,value jsonb not null
+        ,foreign key (time_series_id) references time_series(id)
+);
+
+create table probabilistic_time_series(
+        id integer primary key
+        ,time_series_id integer not null
+        ,uuid text null
+        ,timestamp datetime not null
+        ,value real not null
+        ,foreign key (time_series_id) references time_series(id)
+);
+
+-- View sections
+CREATE VIEW deterministic_time_series_view AS
+WITH json_data AS (
+  SELECT
+    deterministic_time_series.time_series_id
+    ,deterministic_time_series.id
+    ,deterministic_time_series.timestamp
+    ,json_each.value
+    ,ROW_NUMBER() OVER (PARTITION BY deterministic_time_series.id ORDER BY json_each.value) AS horizon
+  FROM deterministic_time_series, json_each(deterministic_time_series.value)
+)
+SELECT time_series_id, id, timestamp, horizon, value
+FROM json_data;
+
+
+-- Trigger section
+CREATE TRIGGER IF not EXISTS autofill_supply
+AFTER INSERT ON supply_technologies
+BEGIN
+    INSERT INTO entities(entity_type, entity_id) VALUES("supply_technologies", new.id);
+END;
+
+CREATE TRIGGER IF not EXISTS autofill_generation_units
+AFTER INSERT ON generation_units
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("generation_units", new.id);
+END;
+
+CREATE TRIGGER IF not EXISTS autofill_storage_units
+AFTER INSERT ON storage_units
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("storage_units", new.id);
+END;
+
+CREATE TRIGGER IF not EXISTS autofill_areas
+AFTER INSERT ON areas
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("areas", new.id);
+END;
+
+CREATE TRIGGER IF not EXISTS autofill_topologies
+AFTER INSERT ON balancing_topologies
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("balancing_topologies", new.id);
+END;
+
+CREATE TRIGGER IF not EXISTS autofill_attributes
+AFTER INSERT ON supplemental_attributes
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("supplemental_attributes", new.id);
+END;
+
+-- Create a trigger that runs after inserting into the arcs table
+CREATE TRIGGER enforce_arc_entity_types_insert
+AFTER INSERT ON arcs
+BEGIN
+    -- Check if the from_to entity has a valid type
+    SELECT CASE
+        WHEN (SELECT entity_type FROM entities WHERE id = NEW.from_to)
+             NOT IN ('balancing_topologies', 'areas')
+        THEN RAISE(ABORT, 'Invalid from_to entity type')
+    END;
+
+    -- Check if the to_from entity has a valid type
+    SELECT CASE
+        WHEN (SELECT entity_type FROM entities WHERE id = NEW.to_from)
+             NOT IN ('balancing_topologies', 'areas')
+        THEN RAISE(ABORT, 'Invalid to_from entity type')
+    END;
+END;
+
+-- Safety mechanism to force json arrays
+-- CREATE TRIGGER enforce_json_array_value_on_deterministic_time_series
+-- BEFORE INSERT ON deterministic_time_series
+-- FOR EACH ROW
+-- WHEN NOT (json_valid(NEW.value) AND json_type(NEW.value, '$') = 'array')
+-- BEGIN
+--     SELECT RAISE(ABORT, 'Value must be a valid JSON array');
+-- END;

--- a/schema.sql
+++ b/schema.sql
@@ -258,7 +258,7 @@ create table time_series_associations (
 -- of a time-varying quantity.
 create table static_time_series (
   id integer primary key
-  ,time_series_id datetime not null
+  ,time_series_id integer not null
   ,uuid text null
   ,timestamp datetime not null
   ,value real not null

--- a/schema.sql
+++ b/schema.sql
@@ -6,6 +6,7 @@ drop view if exists unit_time_series;
 drop table if exists prime_mover_types;
 drop table if exists balancing_topologies;
 drop table if exists supply_technologies;
+drop table if exists storage_technologies;
 drop table if exists transmission_lines;
 drop table if exists demand_requirements;
 drop table if exists areas;
@@ -14,6 +15,10 @@ drop table if exists data_types;
 drop table if exists time_series;
 drop table if exists piecewise_linear;
 drop table if exists transmission_interchange;
+drop table if exists entities;
+drop table if exists linkages;
+drop table if exists reserves;
+drop table if exists operational_data;
 
 -- only generation units
 create table  generation_units (
@@ -22,6 +27,7 @@ create table  generation_units (
 	prime_mover text not null,
 	fuel_type text not null,
 	balancing_topology text not null references balancing_topologies(name),
+	start_year integer not null check (start_year >= 0),
 	rating float not null check (rating > 0 ),
 	base_power float not null check (base_power > 0),
 	check (base_power >= rating),
@@ -37,25 +43,53 @@ create table  storage_units (
 	max_capacity float not null check (max_capacity > 0),
 	round_trip_efficiency float check (round_trip_efficiency >= 0),
 	balancing_topology text not null references balancing_topologies(name),
-	rating float not null check (rating > 0 ),
+	charging_efficiency float not null check (charging_efficiency > 0),
+	discharge_efficiency float not null check (discharge_efficiency > 0),
+	start_year integer not null check (start_year >= 0),
+	rating float not null default 1 check (rating > 0 ),
 	base_power float not null check (base_power > 0),
 	scenario text null,
 	check (base_power >= rating),
 	foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
 );
 
--- create table for technologies
+-- create table for technologies, perhaps change the name to investment_technologies
 create table supply_technologies (
     technology_id integer primary key,
     prime_mover text not null,
-	fuel_type text not null,
-	technology_class real null,
+	  fuel_type text not null,
+	  technology_class real null,
     vom_cost float not null check (vom_cost >= 0),
     fom_cost float not null check (fom_cost >= 0),
     scenario text null,
+	  area text null references areas(name),
+	  balancing_topology text null references balancing_topologies(name),
+	  foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
+);
+
+create table storage_technologies (
+	storage_unit_id integer primary key,
+	name text not null unique,
+	prime_mover text not null,
+	fuel_type text not null,
+	scenario text null,
 	area text null references areas(name),
 	balancing_topology text null references balancing_topologies(name),
 	foreign key (prime_mover, fuel_type) references prime_mover_types(prime_mover, fuel_type)
+);
+
+
+create table operational_data (
+	unit_id references generation_units(unit_id),
+	fom_cost float not null check (fom_cost >= 0),
+	vom_cost float not null check (vom_cost >=0),
+	forced_outage float not null,
+	startup_cost float not null check (startup_cost >= 0),
+	min_stable_level float not null check (min_stable_level >= 0),
+	mttr integer not null check (mttr >= 0),
+	startup_fuel_mmbtu_per_mw float not null check (startup_fuel_mmbtu_per_mw >= 0),
+	uptime float not null check (uptime >= 0),
+	downtime float not null check (downtime >= 0)
 );
 
 -- create table for prime movers
@@ -128,12 +162,60 @@ create table data_types(
 	description text null
 );
 
+create table reserves(
+    id integer primary key,
+    time_frame float not null,
+    requirement float not null,
+    direction text not null
+);
+
+-- Entities gets populated automatically once there is an insert on the core tables.
+create table entities(
+	id integer primary key,
+	entity_type text not null references table_names(name),
+	entity_id integer not null
+);
+
+
+
+CREATE TRIGGER IF NOT EXISTS autofill_supply
+AFTER INSERT ON supply_technologies
+BEGIN
+    INSERT INTO entities(entity_type, entity_id) VALUES("supply_technologies", new.technology_id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_generation_units
+AFTER INSERT ON generation_units
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("generation_units", new.unit_id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_storage_units
+AFTER INSERT ON storage_units
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("storage_units", new.storage_unit_id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_storage_technologies
+AFTER INSERT ON storage_technologies
+BEGIN
+	INSERT INTO entities(entity_type, entity_id) VALUES("storage_technologies", new.storage_unit_id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_reserves
+AFTER INSERT ON reserves
+BEGIN
+    INSERT INTO entities(entity_type, entity_id) VALUES("reserves", new.id);
+END;
+
 -- Create function data table
 
 insert into data_types (name, validation_query) values
 ('integer', 'cast(? as integer) is not null'),
+('float', 'cast(? as float) is not null'),
 ('real', 'cast(? as real) is not null'),
 ('text', 'cast(? as text) is not null'),
+('json', 'json_valid(?) is 1');
 ('time_series', '? is null'),
 ('piecewise_linear', '? is null');
 -- Create a new data type for function data here
@@ -148,32 +230,21 @@ begin
     select case
         when new.data_type = 'integer' and typeof(new.value) != 'integer' then
             raise(fail, 'invalid data type for attribute value. expected integer.')  -- noqa: PRS
-        when new.data_type = 'time_series' and typeof(new.value) != null then
-            raise(fail, 'invalid data type for attribute value. expected real.')  -- noqa: PRS
         when new.data_type = 'text' and typeof(new.value) != 'text' then
             raise(fail, 'invalid data type for attribute value. expected text.')  -- noqa: PRS
-		when new.data_type = 'piecewise_linear' and typeof(new.value) != null then
-			raise(fail, 'invalid data type for attribute value. expected real.')  -- noqa: PRS
+		when new.data_type = 'float' and typeof(new.value) != 'float' then
+			raise(fail, 'invalid data type for attribute value. expected float.')  -- noqa: PRS
+		when new.data_type = 'json' and json_valid(new.value) != 1 then
+            raise(fail, 'invalid data type for attribute value. expected valid JSON.') -- noqa: PRS
     -- add more conditions for other data types as needed
     end;
 end;
 
 
 create table time_series(
-	entity_attribute_id integer references attributes(entity_attribute_id),
-    time_series_blob blob,
-    timestamp int as (time_series_blob ->> 'timestamp'),
-    value float as (time_series_blob ->> 'value')
-);
-
-
-create table piecewise_linear(
-	entity_attribute_id integer references attributes(entity_attribute_id),
-	piecewise_linear_blob blob,
-	from_x float as (piecewise_linear_blob ->> 'from_x'),
-	to_x float as (piecewise_linear_blob ->> 'to_x'),
-	from_y float as (piecewise_linear_blob ->> 'from_y'),
-	to_y float as (piecewise_linear_blob ->> 'to_y')
+	entity_id integer references entities(id),
+	timestamp not null,
+	value float not null
 );
 
 create view unit_attributes as

--- a/triggers.sql
+++ b/triggers.sql
@@ -1,0 +1,202 @@
+/* Autopopulate entity table */
+CREATE TRIGGER IF NOT EXISTS autofill_prime_mover_types
+AFTER
+INSERT
+    ON prime_mover_types
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("prime_mover_types", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_fuels
+AFTER
+INSERT
+    ON fuels
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("fuels", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_planning_regions
+AFTER
+INSERT
+    ON planning_regions
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("planning_regions", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_balancing_topologies
+AFTER
+INSERT
+    ON balancing_topologies
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("balancing_topologies", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_generation_units
+AFTER
+INSERT
+    ON generation_units
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("generation_units", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_storage_units
+AFTER
+INSERT
+    ON storage_units
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("storage_units", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_arcs
+AFTER
+INSERT
+    ON arcs
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("arcs", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_transmission_lines
+AFTER
+INSERT
+    ON transmission_lines
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("transmission_lines", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_transmission_interchanges
+AFTER
+INSERT
+    ON transmission_interchanges
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("transmission_interchanges", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_hydro_reservoir
+AFTER
+INSERT
+    ON hydro_reservoir
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("hydro_reservoir", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_supply_technologies
+AFTER
+INSERT
+    ON supply_technologies
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("supply_technologies", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_transport_technologies
+AFTER
+INSERT
+    ON transport_technologies
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("transport_technologies", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_attributes
+AFTER
+INSERT
+ON attributes
+BEGIN
+  INSERT INTO
+  entities(entity_type, entity_id)
+  VALUES
+  ("attributes", new.id);
+
+END;
+
+CREATE TRIGGER IF NOT EXISTS autofill_supplemental_attributes
+AFTER
+INSERT
+    ON supplemental_attributes
+BEGIN
+INSERT INTO
+    entities(entity_type, entity_id)
+VALUES
+    ("supplemental_attributes", new.id);
+
+END;
+
+-- Create a trigger that runs after inserting into the arcs table
+CREATE TRIGGER IF NOT EXISTS enforce_arc_entity_types_insert
+AFTER
+INSERT
+    ON arcs
+BEGIN
+-- Check if the from_to entity has a valid type
+SELECT
+    CASE
+        WHEN (
+            SELECT
+                entity_type
+            FROM
+                entities
+            WHERE
+                id = NEW.from_to
+        ) NOT IN ('balancing_topologies', 'planning_regions') THEN RAISE(ABORT, 'Invalid from_to entity type')
+    END;
+
+-- Check if the to_from entity has a valid type
+SELECT
+    CASE
+        WHEN (
+            SELECT
+                entity_type
+            FROM
+                entities
+            WHERE
+                id = NEW.to_from
+        ) NOT IN ('balancing_topologies', 'planning_regions') THEN RAISE(ABORT, 'Invalid to_from entity type')
+    END;
+
+END;

--- a/views.sql
+++ b/views.sql
@@ -1,0 +1,23 @@
+CREATE VIEW IF NOT EXISTS deterministic_time_series_view AS WITH json_data AS (
+    SELECT
+        deterministic_forecast_time_series.time_series_id,
+        deterministic_forecast_time_series.id,
+        deterministic_forecast_time_series.timestamp,
+        json_each.value,
+        ROW_NUMBER() OVER (
+            PARTITION BY deterministic_forecast_time_series.id
+            ORDER BY
+                json_each.value
+        ) AS horizon
+    FROM
+        deterministic_forecast_time_series,
+        json_each(deterministic_forecast_time_series.value)
+)
+SELECT
+    time_series_id,
+    id,
+    timestamp,
+    horizon,
+    value
+FROM
+    json_data;


### PR DESCRIPTION
Design Motivation
------------------
When writing the design of the database I thought about this:
- Simplicity and ease of use over complexity,
- Clear, concise and strict fields but allow for extensibility thought supplemental_attributes,
- User friendly (ingestion and reading) over performance,
- All the data is assumed to be in `natural_units`


Notes for reviewers
-------------------

- Review in detail `schema.sql`
- `dummy_data.sql` provide example of how to populate the data on pure SQL, however, I do not intend this to be the main ingestion process, is just an example,
- There is some validation that is done on the tables mostly regarding physical ranges
- We need to agree what gets added as column on the operational data. Right now we have a mixed of overlapping fields that could either go on supplemental attributes or operational_cost,
- The database is just normalized into 2NF for easy use, we could do better (e.g., adding reference to prime_mover_id instead of prime_mover/fuel combo or adding a fuel_table and we reference that one on prime_movers) but since tedious for users to ingest, but open for suggestions,
- DeterministicTimeSeries could hold a json array that provides the different horizons, I created a view such that we can easily ingest this into other formats (e.g., h5)


Breaking changes
------------------

- Some of the tables went a major re-design like `generation_units` with the new supplemental information and some tables got cleaned.