### PR TITLE
Add more types to db serialization

### DIFF
--- a/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
@@ -107,7 +107,7 @@ const SQLITE_CREATE_STR = [
     	name TEXT NOT NULL,
     	obj_type TEXT NOT NULL,
     	arc_id INTEGER NOT NULL,
-    	rating DOUBLE NOT NULL,
+    	rating DOUBLE,
     	PRIMARY KEY (id),
     	UNIQUE (name),
     	FOREIGN KEY(arc_id) REFERENCES arc (id)
@@ -184,7 +184,7 @@ const TABLE_SCHEMAS = Dict(
     ),
     "transmission" => Tables.Schema(
         ["id", "name", "obj_type", "arc_id", "rating"],
-        [Int64, String, String, Int64, Float64],
+        [Int64, String, String, Int64, Union{Nothing, Float64}],
     ),
     "arc" => Tables.Schema(
         ["id", "obj_type", "from_id", "to_id"],
@@ -222,6 +222,7 @@ const TYPE_TO_TABLE_LIST = [
     MonitoredLine => "transmission",
     PhaseShiftingTransformer => "transmission",
     TapTransformer => "transmission",
+    TwoTerminalHVDCLine => "transmission",
     PowerLoad => "load",
     StandardLoad => "load",
     FixedAdmittance => "load",
@@ -249,6 +250,7 @@ const ALL_PSY_TYPES = [
     PSY.MonitoredLine,
     PSY.PhaseShiftingTransformer,
     PSY.TapTransformer,
+    PSY.TwoTerminalHVDCLine,
     PSY.PowerLoad,
     PSY.StandardLoad,
     PSY.FixedAdmittance,

--- a/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
@@ -95,7 +95,7 @@ const SQLITE_CREATE_STR = [
     	name TEXT NOT NULL,
     	obj_type TEXT NOT NULL,
     	bus_id INTEGER NOT NULL,
-    	base_power DOUBLE NOT NULL,
+        base_power DOUBLE,
     	PRIMARY KEY (id),
     	UNIQUE (name),
     	FOREIGN KEY(bus_id) REFERENCES bus (id)
@@ -111,6 +111,20 @@ const SQLITE_CREATE_STR = [
     	PRIMARY KEY (id),
     	UNIQUE (name),
     	FOREIGN KEY(arc_id) REFERENCES arc (id)
+    )
+    """,
+    """
+    CREATE TABLE area_transmission (
+        id INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        obj_type TEXT NOT NULL,
+        from_area INTEGER NOT NULL,
+        to_area INTEGER NOT NULL,
+        rating DOUBLE NOT NULL,
+        PRIMARY KEY (id),
+        UNIQUE (name),
+        FOREIGN KEY(from_area) REFERENCES area (id),
+        FOREIGN KEY(to_area) REFERENCES area (id)
     )
     """,
 ]
@@ -178,7 +192,11 @@ const TABLE_SCHEMAS = Dict(
     ),
     "load" => Tables.Schema(
         ["id", "name", "obj_type", "bus_id", "base_power"],
-        [Int64, String, String, Int64, Float64],
+        [Int64, String, String, Int64, Union{Nothing, Float64}],
+    ),
+    "area_transmission" => Tables.Schema(
+        ["id", "name", "obj_type", "from_area", "to_area", "rating"],
+        [Int64, String, String, Int64, Int64, Float64],
     ),
 )
 
@@ -193,46 +211,62 @@ const OPENAPI_FIELDS_TO_DB = Dict(
 
 const DB_TO_OPENAPI_FIELDS = Dict(t => s for (s, t) in OPENAPI_FIELDS_TO_DB)
 
+const TYPE_TO_TABLE_LIST = [
+    Area => "area",
+    LoadZone => "loadzone",
+    ACBus => "bus",
+    Arc => "arc",
+    AreaInterchange => "area_transmission",
+    Line => "transmission",
+    Transformer2W => "transmission",
+    MonitoredLine => "transmission",
+    PhaseShiftingTransformer => "transmission",
+    TapTransformer => "transmission",
+    PowerLoad => "load",
+    StandardLoad => "load",
+    FixedAdmittance => "load",
+    InterruptiblePowerLoad => "load",
+    ThermalStandard => "generation_unit",
+    RenewableDispatch => "generation_unit",
+    EnergyReservoirStorage => "generation_unit",
+    HydroDispatch => "generation_unit",
+    HydroPumpedStorage => "generation_unit",
+    ThermalMultiStart => "generation_unit",
+    RenewableNonDispatch => "generation_unit",
+    HydroPumpedStorage => "generation_unit",
+    HydroEnergyReservoir => "generation_unit",
+]
+const TYPE_TO_TABLE = Dict(TYPE_TO_TABLE_LIST)
+
 const ALL_PSY_TYPES = [
     PSY.Area,
     PSY.LoadZone,
     PSY.ACBus,
     PSY.Arc,
-    PSY.ThermalStandard,
-    PSY.RenewableDispatch,
+    PSY.AreaInterchange,
     PSY.Line,
     PSY.Transformer2W,
+    PSY.MonitoredLine,
+    PSY.PhaseShiftingTransformer,
+    PSY.TapTransformer,
     PSY.PowerLoad,
     PSY.StandardLoad,
-]
-const ALL_TYPES = [
-    Area,
-    LoadZone,
-    ACBus,
-    Arc,
-    ThermalStandard,
-    RenewableDispatch,
-    Line,
-    Transformer2W,
-    PowerLoad,
-    StandardLoad,
+    PSY.FixedAdmittance,
+    PSY.InterruptiblePowerLoad,
+    PSY.ThermalStandard,
+    PSY.RenewableDispatch,
+    PSY.EnergyReservoirStorage,
+    PSY.HydroDispatch,
+    PSY.HydroPumpedStorage,
+    PSY.ThermalMultiStart,
+    PSY.RenewableNonDispatch,
+    PSY.HydroPumpedStorage,
+    PSY.HydroEnergyReservoir,
 ]
 
+const ALL_TYPES = first.(TYPE_TO_TABLE_LIST)
 const PSY_TO_OPENAPI_TYPE = Dict(k => v for (k, v) in zip(ALL_PSY_TYPES, ALL_TYPES))
-
 const TYPE_NAMES = Dict(string(t) => t for t in ALL_TYPES)
-const TYPE_TO_TABLE = Dict(
-    ACBus => "bus",
-    Area => "area",
-    Arc => "arc",
-    Line => "transmission",
-    LoadZone => "loadzone",
-    PowerLoad => "load",
-    ThermalStandard => "generation_unit",
-    Transformer2W => "transmission",
-    RenewableDispatch => "generation_unit",
-    StandardLoad => "load",
-)
 
 function make_sqlite!(db)
     for table in SQLITE_CREATE_STR

--- a/SiennaOpenAPIModels.jl/test/test-db.jl
+++ b/SiennaOpenAPIModels.jl/test/test-db.jl
@@ -86,6 +86,9 @@ end
         PowerSystemCaseBuilder.PSISystems,
         "RTS_GMLC_RT_sys",
     )
+    for fixed_admittance in PSY.get_components(PSY.FixedAdmittance, sys)
+        PSY.set_name!(sys, fixed_admittance, PSY.get_name(fixed_admittance) * "_admitatnce")
+    end
     db = SQLite.DB()
     SiennaOpenAPIModels.make_sqlite!(db)
     SiennaOpenAPIModels.sys2db!(db, sys, IDGenerator())


### PR DESCRIPTION
- Adds several types to the list of supported types.
- Required slight modifications to the db
- RTS system parsing involved duplicated load names with the inclusion of the FixedAdmittance at Camus.
   
  I've modified the RTS system in that call to change the names of the FixedAdmittance objects, but we really need to have a kind of fallback.