### PR TITLE
Add entity type / entity_table distinction

### DIFF
--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -24,7 +24,7 @@ VALUES
     ('ThermalStandard'),
     ('HydroDispatch'),
     ('RenewableDispatch'),
-    ('EnergyReservoir'),
+    ('EnergyReservoirStorage'),
     ('Arc'),
     ('Line'),
     ('SupplyTechnology'),

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -17,10 +17,24 @@ VALUES
     ("Oil", "Oil");
 
 INSERT INTO
-    entities (id, entity_type)
+    entity_types (name)
 VALUES
-    (0, 'planning_regions'),
-    (1, 'planning_regions');
+    ('Area'),
+    ('ACBus'),
+    ('ThermalStandard'),
+    ('HydroDispatch'),
+    ('RenewableDispatch'),
+    ('EnergyReservoir'),
+    ('Arc'),
+    ('Line'),
+    ('SupplyTechnology'),
+    ('SupplementalAttribute');
+
+INSERT INTO
+    entities (id, entity_table, entity_type)
+VALUES
+    (0, 'planning_regions', 'Area'),
+    (1, 'planning_regions', 'Area');
 
 -- Areas are the higher level aggregation of balancing topologies
 INSERT INTO
@@ -30,16 +44,16 @@ VALUES
     (1, 'South', 'Southern region');
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (2, 'balancing_topologies'),
-    (3, 'balancing_topologies'),
-    (4, 'balancing_topologies'),
-    (5, 'balancing_topologies'),
-    (6, 'balancing_topologies'),
-    (7, 'balancing_topologies'),
-    (8, 'balancing_topologies'),
-    (9, 'balancing_topologies');
+    (2, 'balancing_topologies', 'ACBus'),
+    (3, 'balancing_topologies', 'ACBus'),
+    (4, 'balancing_topologies', 'ACBus'),
+    (5, 'balancing_topologies', 'ACBus'),
+    (6, 'balancing_topologies', 'ACBus'),
+    (7, 'balancing_topologies', 'ACBus'),
+    (8, 'balancing_topologies', 'ACBus'),
+    (9, 'balancing_topologies', 'ACBus');
 
 -- Balancing topologies are the lower level aggregation of generation units
 INSERT INTO
@@ -95,12 +109,12 @@ VALUES
     );
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (10, 'generation_units'),
-    (11, 'generation_units'),
-    (12, 'generation_units'),
-    (13, 'generation_units');
+    (10, 'generation_units', 'ThermalStandard'),
+    (11, 'generation_units', 'HydroDispatch'),
+    (12, 'generation_units', 'RenewableDispatch'),
+    (13, 'generation_units', 'RenewableDispatch');
 
 -- Inserting data for generation units
 INSERT INTO
@@ -120,11 +134,11 @@ VALUES
     (13, 'Unit 4', 'WT', NULL, 9, 1, 200);
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (14, 'storage_units'),
-    (15, 'storage_units'),
-    (16, 'storage_units');
+    (14, 'storage_units', 'EnergyReservoir'),
+    (15, 'storage_units', 'EnergyReservoir'),
+    (16, 'storage_units', 'EnergyReservoir');
 
 -- Inserting data for storage units
 INSERT INTO
@@ -171,11 +185,11 @@ VALUES
     );
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (17, 'arcs'),
-    (18, 'arcs'),
-    (19, 'arcs');
+    (17, 'arcs', 'Arc'),
+    (18, 'arcs', 'Arc'),
+    (19, 'arcs', 'Arc');
 
 -- Insert some arcs
 INSERT INTO
@@ -194,10 +208,10 @@ VALUES
     (19, 7, 8);
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (20, 'transmission_lines'),
-    (21, 'transmission_lines');
+    (20, 'transmission_lines', 'Line'),
+    (21, 'transmission_lines', 'Line');
 
 -- Inserting data for transmission lines
 INSERT INTO
@@ -231,12 +245,12 @@ VALUES
     );
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (22, 'supply_technologies'),
-    (23, 'supply_technologies'),
-    (24, 'supply_technologies'),
-    (25, 'supply_technologies');
+    (22, 'supply_technologies', 'SupplyTechnology'),
+    (23, 'supply_technologies', 'SupplyTechnology'),
+    (24, 'supply_technologies', 'SupplyTechnology'),
+    (25, 'supply_technologies', 'SupplyTechnology');
 
 -- Inserting data for investment technologies
 INSERT INTO
@@ -254,10 +268,18 @@ VALUES
     (25, "PV", NULL, "region_02", NULL);
 
 INSERT INTO
-    entities (id, entity_type)
+    entities (id, entity_table, entity_type)
 VALUES
-    (26, 'supplemental_attributes'),
-    (27, 'supplemental_attributes');
+    (
+        26,
+        'supplemental_attributes',
+        'SupplementalAttribute'
+    ),
+    (
+        27,
+        'supplemental_attributes',
+        'SupplementalAttribute'
+    );
 
 -- Supplemental attributes
 INSERT INTO

--- a/schema.sql
+++ b/schema.sql
@@ -55,9 +55,13 @@ DROP TABLE IF EXISTS transport_technologies;
 -- Table of certain entities of griddb schema.
 CREATE TABLE entities (
     id integer PRIMARY KEY,
+    entity_table text NOT NULL,
     entity_type text NOT NULL,
-    UNIQUE (id, entity_type)
+    FOREIGN KEY (entity_type) REFERENCES entity_types (name)
 );
+
+-- Table of possible entity types
+CREATE TABLE entity_types (name text PRIMARY KEY);
 
 -- NOTE: Sienna-griddb follows the convention of the EIA prime mover where we
 -- have a `prime_mover` and `fuel` to classify generators/storage units.

--- a/triggers.sql
+++ b/triggers.sql
@@ -107,7 +107,7 @@ SELECT
         -- Check if from_id entity type is valid
         WHEN (
             SELECT
-                entity_type
+                entity_table
             FROM
                 entities
             WHERE
@@ -118,7 +118,7 @@ SELECT
         ) -- Check if to_id entity type is valid
         WHEN (
             SELECT
-                entity_type
+                entity_table
             FROM
                 entities
             WHERE
@@ -129,14 +129,14 @@ SELECT
         ) -- Check if from_id and to_id entity types match
         WHEN (
             SELECT
-                entity_type
+                entity_table
             FROM
                 entities
             WHERE
                 id = NEW.from_id
         ) != (
             SELECT
-                entity_type
+                entity_table
             FROM
                 entities
             WHERE


### PR DESCRIPTION
Alternatives:
1. Try to autodetect the appropriate OpenAPI model during parse time
2. Force the user to specify during parsing
3. Placed on the tables instead
4. Make it nullable and fail during parsing or try to autodetect somehow.