### PR TITLE
Add time series serialization

### DIFF
--- a/SiennaOpenAPIModels.jl/Project.toml
+++ b/SiennaOpenAPIModels.jl/Project.toml
@@ -16,7 +16,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [sources]
-InfrastructureSystems = {rev = "feat/irregular-resolutions", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
+InfrastructureSystems = {rev = "main", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
 PowerSystems = {rev = "psy5", url = "https://github.com/NREL-Sienna/PowerSystems.jl"}
 
 [compat]

--- a/SiennaOpenAPIModels.jl/Project.toml
+++ b/SiennaOpenAPIModels.jl/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OpenAPI = "d5e62ea6-ddf3-4d43-8e4c-ad5e6c8bfd7d"
@@ -15,11 +16,12 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [sources]
-InfrastructureSystems = {rev = "main", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
+InfrastructureSystems = {rev = "feat/irregular-resolutions", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
 PowerSystems = {rev = "psy5", url = "https://github.com/NREL-Sienna/PowerSystems.jl"}
 
 [compat]
 DBInterface = "2.6.1"
+Dates = "1.11.0"
 InfrastructureSystems = "2.6.0"
 JSON = "0.21.4"
 SQLite = "1.6.1"

--- a/SiennaOpenAPIModels.jl/src/SiennaOpenAPIModels.jl
+++ b/SiennaOpenAPIModels.jl/src/SiennaOpenAPIModels.jl
@@ -12,6 +12,7 @@ module SiennaOpenAPIModels
 using OpenAPI
 using StructHelpers: @batteries
 import PowerSystems
+import Dates
 
 const PSY = PowerSystems
 const API_VERSION = "1.0.0"
@@ -123,6 +124,7 @@ include("json_to_sienna/service.jl")
 include("dbinterface/value_curve.jl")
 
 include("dbinterface/sqlite.jl")
+include("dbinterface/time_series.jl")
 
 """
 Register handlers for all APIs in this module in the supplied `Router` instance.

--- a/SiennaOpenAPIModels.jl/src/dbinterface/db_definition.jl
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/db_definition.jl
@@ -135,7 +135,7 @@ const TABLE_SCHEMAS = Dict(
     ),
     "supplemental_attributes_association" =>
         Tables.Schema(["attribute_id", "entity_id"], [Int64, Int64]),
-    "time_series" => Tables.Schema(
+    "time_series_associations" => Tables.Schema(
         [
             "id",
             "time_series_uuid",
@@ -143,13 +143,17 @@ const TABLE_SCHEMAS = Dict(
             "initial_timestamp",
             "resolution",
             "horizon",
-            "INTERVAL",
+            "interval",
             "window_count",
             "length",
-            "scaling_multiplier",
             "name",
             "owner_id",
+            "owner_type",
+            "owner_category",
             "features",
+            "scaling_factor_multiplier",
+            "metadata_uuid",
+            "units",
         ],
         [
             Int64,
@@ -165,16 +169,18 @@ const TABLE_SCHEMAS = Dict(
             String,
             Int64,
             Union{String, Nothing},
+            Union{String, Nothing},
+            Union{String, Nothing},
+            Union{String, Nothing},
+            Union{String, Nothing},
         ],
     ),
     "loads" => Tables.Schema(
         ["id", "name", "balancing_topology", "base_power"],
         [Int64, String, Int64, Union{Float64, Nothing}],
     ),
-    "static_time_series" => Tables.Schema(
-        ["id", "uuid", "timestamp", "value"],
-        [Int64, String, String, Float64],
-    ),
+    "static_time_series" =>
+        Tables.Schema(["id", "uuid", "idx", "value"], [Int64, String, Int64, Float64]),
 )
 
 function make_sqlite!(db)

--- a/SiennaOpenAPIModels.jl/src/dbinterface/schema.sql
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/schema.sql
@@ -22,8 +22,6 @@ DROP TABLE IF EXISTS transmission_lines;
 
 DROP TABLE IF EXISTS planning_regions;
 
-DROP TABLE IF EXISTS time_series;
-
 DROP TABLE IF EXISTS transmission_interchanges;
 
 DROP TABLE IF EXISTS entities;
@@ -270,7 +268,7 @@ CREATE TABLE time_series_associations(
     window_count INTEGER,
     length INTEGER,
     name TEXT NOT NULL,
-    owner_uuid TEXT NOT NULL,
+    owner_id INTEGER NOT NULL REFERENCES entities(id),
     owner_type TEXT NOT NULL,
     owner_category TEXT NOT NULL,
     features TEXT NOT NULL,
@@ -279,7 +277,7 @@ CREATE TABLE time_series_associations(
     units TEXT NULL
 );
 CREATE UNIQUE INDEX "by_c_n_tst_features" ON "time_series_associations" (
-    "owner_uuid",
+    "owner_id",
     "time_series_type",
     "name",
     "resolution",

--- a/SiennaOpenAPIModels.jl/src/dbinterface/schema.sql
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/schema.sql
@@ -273,7 +273,7 @@ CREATE TABLE time_series_associations(
     owner_type TEXT NOT NULL,
     owner_category TEXT NOT NULL,
     features TEXT NOT NULL,
-    scaling_factor_multiplier JSON NULL,
+    scaling_factor_multiplier TEXT NULL,
     metadata_uuid TEXT NOT NULL,
     units TEXT NULL
 );
@@ -302,7 +302,7 @@ CREATE TABLE loads (
 -- of a time-varying quantity.
 CREATE TABLE static_time_series (
     id integer PRIMARY KEY,
-    uuid text NULL UNIQUE,
+    uuid text NULL,
     timestamp datetime NOT NULL,
     value real NOT NULL
 );

--- a/SiennaOpenAPIModels.jl/src/dbinterface/schema.sql
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/schema.sql
@@ -223,6 +223,7 @@ CREATE TABLE operational_data (
     FOREIGN KEY (entity_id) REFERENCES entities(id)
 );
 
+
 -- NOTE: Attributes are additional parameters that can be linked to entities.
 -- The main purpose of this is when there is an important field that is not
 -- capture on the entity table that should exist on the model. Example of this
@@ -265,7 +266,7 @@ CREATE TABLE time_series_associations(
     initial_timestamp TEXT NOT NULL,
     resolution TEXT NOT NULL,
     horizon TEXT,
-    INTERVAL TEXT,
+    "interval" TEXT,
     window_count INTEGER,
     length INTEGER,
     name TEXT NOT NULL,
@@ -295,14 +296,9 @@ CREATE TABLE loads (
     FOREIGN KEY(balancing_topology) REFERENCES balancing_topologies (id)
 );
 
--- From Sienna docs:
--- A static time series data is a single column of data where each time period has
--- a single value assigned to a component field, such as its maximum active power.
--- This data commonly is obtained from historical information or the realization
--- of a time-varying quantity.
 CREATE TABLE static_time_series (
     id integer PRIMARY KEY,
     uuid text NULL,
-    timestamp datetime NOT NULL,
+    idx integer NOT NULL,
     value real NOT NULL
 );

--- a/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
@@ -391,6 +391,8 @@ function db2sys!(sys::PSY.System, db, resolver::Resolver)
            table_name == "prime_mover_types" ||
            table_name == "fuels" ||
            table_name == "entity_types" ||
+           table_name == "time_series_associations" ||
+           table_name == "static_time_series" ||
            table_name == "time_series"
             continue
         end

--- a/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/sqlite.jl
@@ -214,11 +214,14 @@ function send_table_to_db!(::Type{T}, db, components, ids) where {T}
     )
 end
 
-function sys2db!(db, sys::PSY.System, ids::IDGenerator)
+function sys2db!(db, sys::PSY.System, ids::IDGenerator; time_series=false)
     DBInterface.transaction(db) do
         for (T, OPENAPI_T) in zip(ALL_PSY_TYPES, ALL_TYPES)
             send_table_to_db!(OPENAPI_T, db, PSY.get_components(T, sys), ids)
         end
+    end
+    if time_series
+        serialize_timeseries!(db, sys, ids)
     end
 end
 
@@ -392,8 +395,7 @@ function db2sys!(sys::PSY.System, db, resolver::Resolver)
            table_name == "fuels" ||
            table_name == "entity_types" ||
            table_name == "time_series_associations" ||
-           table_name == "static_time_series" ||
-           table_name == "time_series"
+           table_name == "static_time_series"
             continue
         end
         result = DBInterface.execute(db, "SELECT count(*) from $table_name")
@@ -405,9 +407,12 @@ function db2sys!(sys::PSY.System, db, resolver::Resolver)
     end
 end
 
-function make_system_from_db(db)
+function make_system_from_db(db; time_series=false)
     sys = PSY.System(100)
     resolver = Resolver(sys, Dict{Int64, UUID}())
     db2sys!(sys, db, resolver)
+    if time_series
+        deserialize_timeseries!(sys, db, resolver)
+    end
     return sys
 end

--- a/SiennaOpenAPIModels.jl/src/dbinterface/time_series.jl
+++ b/SiennaOpenAPIModels.jl/src/dbinterface/time_series.jl
@@ -1,0 +1,261 @@
+const INFRASYS_TS_SCHEMA = Tables.Schema(
+    [
+        "id",
+        "time_series_uuid",
+        "time_series_type",
+        "initial_timestamp",
+        "resolution",
+        "horizon",
+        "interval",
+        "window_count",
+        "length",
+        "name",
+        "owner_uuid",
+        "owner_type",
+        "owner_category",
+        "features",
+        "scaling_factor_multiplier",
+        "metadata_uuid",
+        "units",
+    ],
+    [
+        Int64,
+        String,
+        String,
+        String,
+        String,
+        Union{Missing, String},
+        Union{Missing, String},
+        Union{Missing, Int64},
+        Union{Missing, Int64},
+        String,
+        String,
+        String,
+        String,
+        String,
+        Union{Missing, String},
+        Base.UUID,
+        Union{Missing, String},
+    ],
+)
+
+function get_uuid_mapping(sys::PowerSystems.System)
+    metadata_store = sys.data.time_series_manager.metadata_store
+
+    time_series_uuids = IS.sql(
+        metadata_store,
+        """
+        SELECT DISTINCT metadata_uuid, time_series_uuid, time_series_type, initial_timestamp, resolution, horizon, interval, window_count, length
+        FROM time_series_associations
+        """,
+    )
+
+    # Create a mapping from original time_series_uuid to new unique UUIDs for duplicates
+    uuid_count = Dict{String, Int64}()
+    uuid_mapping = Dict{String, Base.UUID}()
+
+    for row in Tables.rows(time_series_uuids)
+        uuid = row.time_series_uuid
+        if haskey(uuid_count, uuid)
+            # Duplicate found, assign a new UUID
+            new_uuid = UUIDs.uuid4()
+            uuid_count[uuid] += 1
+            uuid_mapping[row.metadata_uuid] = new_uuid
+        else
+            uuid_count[uuid] = 1
+            uuid_mapping[row.metadata_uuid] = Base.UUID(uuid)
+        end
+    end
+
+    return uuid_mapping
+end
+
+function get_time_series_from_metadata_uuid(sys::PowerSystems.System, metadata_uuid)
+    ts_metadata = sys.data.time_series_manager.metadata_store.metadata_uuids[metadata_uuid]
+
+    start_time = IS._check_start_time(nothing, ts_metadata)
+    rows = IS._get_rows(start_time, nothing, ts_metadata)
+    columns = IS._get_columns(start_time, nothing, ts_metadata)
+    storage = sys.data.time_series_manager.data_store
+
+    return InfrastructureSystems.deserialize_time_series(
+        InfrastructureSystems.time_series_metadata_to_data(ts_metadata),
+        storage,
+        ts_metadata,
+        rows,
+        columns,
+    )
+end
+
+"""
+Writes time series as rows (time_series_uuid, timestamp, value)
+"""
+function serialize_timeseries_data!(
+    db,
+    ts::PowerSystems.SingleTimeSeries,
+    time_series_uuid::Base.UUID,
+)
+    stmt = DBInterface.prepare(
+        db,
+        """
+        INSERT INTO static_time_series (uuid, timestamp, value)
+        VALUES (?, ?, ?)
+        """,
+    )
+    for (timestamp, value) in ts
+        DBInterface.execute(stmt, (string(time_series_uuid), string(timestamp), value))
+    end
+end
+
+"""
+Writes time series as rows (time_series_uuid, timestamp, value)
+"""
+function serialize_timeseries_data!(
+    db,
+    ts::PowerSystems.DeterministicSingleTimeSeries,
+    time_series_uuid::Base.UUID,
+)
+    serialize_timeseries_data!(db, ts.single_time_series, time_series_uuid)
+end
+
+"""
+Iterate through all metadata objects and serialize timeseries
+"""
+function serialize_all_timeseries_data!(db, sys::PowerSystems.System)
+    metadata_uuid_to_new_time_series_uuids = get_uuid_mapping(sys)
+
+    for (metadata_uuid, time_series_uuid) in metadata_uuid_to_new_time_series_uuids
+        ts = get_time_series_from_metadata_uuid(sys, Base.UUID(metadata_uuid))
+        serialize_timeseries_data!(db, ts, time_series_uuid)
+    end
+    return metadata_uuid_to_new_time_series_uuids
+end
+
+function transform_associations!(sys::PowerSystems.System, associations, uuid_mapping)
+    associations = PowerSystems.DataFrames.coalesce.(associations, nothing)
+    associations[!, "time_series_uuid"] =
+        map(x -> string(uuid_mapping[x]), associations[!, "metadata_uuid"])
+    #associations[!, "owner_id"] = map(onwer_uuid -> getid!(ids, owner_uuid), associations[!, "owner_uuid"])
+    return associations
+end
+
+function serialize_timeseries_associations!(db, sys::PowerSystems.System, uuid_mapping)
+    associations = IS.sql(
+        sys.data.time_series_manager.metadata_store,
+        """SELECT $(join(INFRASYS_TS_SCHEMA.names, ", "))
+FROM time_series_associations;""",
+    )
+    associations = transform_associations!(sys, associations, uuid_mapping)
+
+    statement = DBInterface.prepare(
+        db,
+        """INSERT INTO time_series_associations ($(join(INFRASYS_TS_SCHEMA.names, ", ")))
+VALUES ($(join(repeat("?", length(INFRASYS_TS_SCHEMA.names)), ", ")))""",
+    )
+
+    for row in Tables.rowtable(associations)
+        DBInterface.execute(statement, tuple(row...))
+    end
+end
+
+function serialize_timeseries!(db, sys::PowerSystems.System)
+    uuid_mapping = serialize_all_timeseries_data!(db, sys)
+    serialize_timeseries_associations!(db, sys, uuid_mapping)
+end
+
+function deserialize_timedata(
+    db,
+    ::InfrastructureSystems.SingleTimeSeriesMetadata,
+    time_series_uuid,
+)
+    stmt = DBInterface.prepare(
+        db,
+        """
+        SELECT timestamp, value
+        FROM static_time_series
+        WHERE uuid = ?
+        ORDER BY timestamp
+        """,
+    )
+    rows = DBInterface.execute(stmt, (string(time_series_uuid),))
+    column_table = Tables.columntable(rows)
+    return PowerSystems.TimeSeries.TimeArray(
+        Dates.DateTime.(column_table.timestamp),
+        column_table.value,
+    )
+end
+
+function deserialize_time_series_row!(sys, db, row)
+    metadata = deserialize_metadata(row)
+    time_array = deserialize_timedata(db, metadata, row.time_series_uuid)
+    ts = InfrastructureSystems.time_series_metadata_to_data(metadata)(metadata, time_array)
+    PowerSystems.add_time_series!(sys, PowerSystems.get_component(sys, row.owner_uuid), ts)
+end
+
+# TODO: STOLEN FROM InfrastructureSystems. This should be made an IS functions.
+function deserialize_metadata(row)
+    exclude_keys = Set((:metadata_uuid, :owner_uuid, :time_series_type))
+    time_series_type =
+        InfrastructureSystems.TIME_SERIES_STRING_TO_TYPE[row.time_series_type]
+    metadata_type = InfrastructureSystems.time_series_data_to_metadata(time_series_type)
+    fields = Set(fieldnames(metadata_type))
+    data = Dict{Symbol, Any}(
+        :internal => InfrastructureSystems.InfrastructureSystemsInternal(;
+            uuid=Base.UUID(row.metadata_uuid),
+        ),
+    )
+    if time_series_type <: InfrastructureSystems.Forecast
+        # Special case because the table column does not match the field name.
+        data[:count] = row.window_count
+    end
+    if time_series_type <: InfrastructureSystems.AbstractDeterministic
+        data[:time_series_type] = time_series_type
+    end
+    for field in keys(row)
+        if !in(field, fields) || field in exclude_keys
+            continue
+        end
+        val = getproperty(row, field)
+        if field == :initial_timestamp
+            data[field] = Dates.DateTime(val)
+        elseif field == :resolution
+            data[field] = InfrastructureSystems.from_iso_8601(val)
+        elseif field == :horizon || field == :interval
+            if !ismissing(val)
+                data[field] = InfrastructureSystems.from_iso_8601(val)
+            end
+        elseif field == :time_series_uuid
+            data[field] = Base.UUID(val)
+        elseif field == :features
+            features_array = InfrastructureSystems.JSON3.read(val, Array)
+            features_dict = Dict{String, Union{Bool, Int, String}}()
+            for obj in features_array
+                length(obj) != 1 && error("Invalid features: $obj")
+                key = first(keys(obj))
+                key in keys(features_dict) && error("Duplicate features: $key")
+                features_dict[key] = obj[key]
+            end
+            data[field] = features_dict
+        elseif field == :scaling_factor_multiplier
+            if !ismissing(val)
+                val2 = InfrastructureSystems.JSON3.read(val, Dict{String, Any})
+                data[field] = InfrastructureSystems.deserialize(Function, val2)
+            end
+        else
+            data[field] = val
+        end
+    end
+    return metadata_type(; data...)
+end
+
+function deserialize_timeseries!(sys::PowerSystems.System, db)
+    associations = DBInterface.execute(
+        db,
+        """SELECT $(join(INFRASYS_TS_SCHEMA.names, ", "))
+FROM time_series_associations;""",
+    )
+
+    for row in associations
+        deserialize_time_series_row!(sys, db, row)
+    end
+end

--- a/SiennaOpenAPIModels.jl/test/Project.toml
+++ b/SiennaOpenAPIModels.jl/test/Project.toml
@@ -9,6 +9,7 @@ SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 SiennaOpenAPIModels = "6f904ddb-d94b-53ea-97a4-b251110faebf"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [sources]
 PowerSystemCaseBuilder = {url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl", rev = "psy5"}

--- a/SiennaOpenAPIModels.jl/test/test-time-series.jl
+++ b/SiennaOpenAPIModels.jl/test/test-time-series.jl
@@ -1,3 +1,32 @@
+import TimeSeries
+
+InfrastructureSystems._is_compare_directly(::TimeSeries.TimeArray, ::TimeSeries.TimeArray) =
+    true
+
+function test_all_time_series(sys1::PSY.System, sys2::PSY.System)
+    for T in SiennaOpenAPIModels.ALL_DESERIALIZABLE_TYPES
+        SIENNA_T = SiennaOpenAPIModels.OPENAPI_TYPE_TO_PSY[T]
+        for c in PowerSystems.get_components(SIENNA_T, sys1)
+            new_component = PSY.get_component(SIENNA_T, sys2, PSY.get_name(c))
+            if PowerSystems.has_time_series(c)
+                for key in PowerSystems.get_time_series_keys(c)
+                    ts = PowerSystems.get_time_series(c, key)
+                    @test PowerSystems.has_time_series(new_component)
+                    new_ts = PowerSystems.get_time_series(new_component, key)
+                    @test !isnothing(new_ts)
+                    @test IS.compare_values(
+                        custom_isequivalent,
+                        ts,
+                        new_ts,
+                        compare_uuids=false,
+                        exclude=Set([:units_info, :ext, :services]),
+                    )
+                end
+            end
+        end
+    end
+end
+
 @testset "c_sys5_pjm time-series to DB" begin
     sys =
         PowerSystemCaseBuilder.build_system(PowerSystemCaseBuilder.PSISystems, "c_sys5_pjm")
@@ -6,11 +35,57 @@
     SiennaOpenAPIModels.make_sqlite!(db)
     ids = IDGenerator()
     SiennaOpenAPIModels.sys2db!(db, sys, ids)
-
     SiennaOpenAPIModels.serialize_timeseries!(db, sys)
 
     copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
     SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
     @test copy_of_sys isa PSY.System
     test_component_each_type(sys, copy_of_sys)
+    test_all_time_series(sys, copy_of_sys)
+end
+
+@testset "5bus matpower RT time-series to DB" begin
+    sys = PowerSystemCaseBuilder.build_system(
+        PowerSystemCaseBuilder.PSISystems,
+        "5_bus_matpower_RT",
+    )
+    db = SQLite.DB()
+    SiennaOpenAPIModels.make_sqlite!(db)
+    ids = IDGenerator()
+    SiennaOpenAPIModels.sys2db!(db, sys, ids)
+    SiennaOpenAPIModels.serialize_timeseries!(db, sys)
+
+    copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
+    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
+    @test copy_of_sys isa PSY.System
+    #test_component_each_type(sys, copy_of_sys)  # it has dynamic injectors
+    test_all_time_series(sys, copy_of_sys)
+end
+
+@testset "RTS_GMLC_RT_sys time-series to DB" begin
+    sys = PowerSystemCaseBuilder.build_system(
+        PowerSystemCaseBuilder.PSISystems,
+        "RTS_GMLC_DA_sys",
+    )
+
+    # Apply the same fixes as in test-db.jl for RTS system
+    for fixed_admittance in PSY.get_components(PSY.FixedAdmittance, sys)
+        PSY.set_name!(sys, fixed_admittance, PSY.get_name(fixed_admittance) * "_admitatnce")
+    end
+    for thermal_standard in
+        PSY.get_components(x -> x.base_power == 0.0, PSY.ThermalStandard, sys)
+        PSY.set_base_power!(thermal_standard, 0.001)
+    end
+
+    db = SQLite.DB()
+    SiennaOpenAPIModels.make_sqlite!(db)
+    ids = IDGenerator()
+    SiennaOpenAPIModels.sys2db!(db, sys, ids)
+    SiennaOpenAPIModels.serialize_timeseries!(db, sys)
+
+    copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
+    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
+    @test copy_of_sys isa PSY.System
+    test_component_each_type(sys, copy_of_sys)
+    test_all_time_series(sys, copy_of_sys)
 end

--- a/SiennaOpenAPIModels.jl/test/test-time-series.jl
+++ b/SiennaOpenAPIModels.jl/test/test-time-series.jl
@@ -35,10 +35,12 @@ end
     SiennaOpenAPIModels.make_sqlite!(db)
     ids = IDGenerator()
     SiennaOpenAPIModels.sys2db!(db, sys, ids)
-    SiennaOpenAPIModels.serialize_timeseries!(db, sys)
+    SiennaOpenAPIModels.serialize_timeseries!(db, sys, ids)
 
-    copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
-    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
+    copy_of_sys = PSY.System(100)
+    resolver = SiennaOpenAPIModels.Resolver(copy_of_sys, Dict{Int64, Base.UUID}())
+    SiennaOpenAPIModels.db2sys!(copy_of_sys, db, resolver)
+    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db, resolver)
     @test copy_of_sys isa PSY.System
     test_component_each_type(sys, copy_of_sys)
     test_all_time_series(sys, copy_of_sys)
@@ -53,10 +55,12 @@ end
     SiennaOpenAPIModels.make_sqlite!(db)
     ids = IDGenerator()
     SiennaOpenAPIModels.sys2db!(db, sys, ids)
-    SiennaOpenAPIModels.serialize_timeseries!(db, sys)
+    SiennaOpenAPIModels.serialize_timeseries!(db, sys, ids)
 
-    copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
-    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
+    copy_of_sys = PSY.System(100)
+    resolver = SiennaOpenAPIModels.Resolver(copy_of_sys, Dict{Int64, Base.UUID}())
+    SiennaOpenAPIModels.db2sys!(copy_of_sys, db, resolver)
+    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db, resolver)
     @test copy_of_sys isa PSY.System
     #test_component_each_type(sys, copy_of_sys)  # it has dynamic injectors
     test_all_time_series(sys, copy_of_sys)
@@ -81,10 +85,12 @@ end
     SiennaOpenAPIModels.make_sqlite!(db)
     ids = IDGenerator()
     SiennaOpenAPIModels.sys2db!(db, sys, ids)
-    SiennaOpenAPIModels.serialize_timeseries!(db, sys)
+    SiennaOpenAPIModels.serialize_timeseries!(db, sys, ids)
 
-    copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
-    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
+    copy_of_sys = PSY.System(100)
+    resolver = SiennaOpenAPIModels.Resolver(copy_of_sys, Dict{Int64, Base.UUID}())
+    SiennaOpenAPIModels.db2sys!(copy_of_sys, db, resolver)
+    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db, resolver)
     @test copy_of_sys isa PSY.System
     test_component_each_type(sys, copy_of_sys)
     test_all_time_series(sys, copy_of_sys)

--- a/SiennaOpenAPIModels.jl/test/test-time-series.jl
+++ b/SiennaOpenAPIModels.jl/test/test-time-series.jl
@@ -1,0 +1,16 @@
+@testset "c_sys5_pjm time-series to DB" begin
+    sys =
+        PowerSystemCaseBuilder.build_system(PowerSystemCaseBuilder.PSISystems, "c_sys5_pjm")
+
+    db = SQLite.DB()
+    SiennaOpenAPIModels.make_sqlite!(db)
+    ids = IDGenerator()
+    SiennaOpenAPIModels.sys2db!(db, sys, ids)
+
+    SiennaOpenAPIModels.serialize_timeseries!(db, sys)
+
+    copy_of_sys = SiennaOpenAPIModels.make_system_from_db(db)
+    SiennaOpenAPIModels.deserialize_timeseries!(copy_of_sys, db)
+    @test copy_of_sys isa PSY.System
+    test_component_each_type(sys, copy_of_sys)
+end


### PR DESCRIPTION
- Currently only covers SingleTimeSeries and DeterministicSingleTimeSeries
- I had to change the schema to use idx instead of timestamps in the static_time_series.
- It will not preserve the metadata_uuid for some of the time series uuids.
- It does correctly do sharing of time series data if the underlying system does.