### PR TITLE
hc/more_psy5_changes

### DIFF
--- a/SiennaOpenAPIModels.jl/docs/HydroDispatch.md
+++ b/SiennaOpenAPIModels.jl/docs/HydroDispatch.md
@@ -1,26 +1,25 @@
 # HydroDispatch
 
-
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**active_power** | **Float64** |  | [default to nothing]
-**active_power_limits** | [***MinMax**](MinMax.md) |  | [default to nothing]
-**available** | **Bool** |  | [default to nothing]
-**base_power** | **Float64** |  | [default to nothing]
-**bus** | **Int64** |  | [default to nothing]
 **id** | **Int64** |  | [default to nothing]
 **name** | **String** |  | [default to nothing]
-**operation_cost** | [***HydroGenerationCost**](HydroGenerationCost.md) |  | [optional] [default to nothing]
-**prime_mover_type** | **String** |  | [default to "OT"]
-**ramp_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
-**rating** | **Float64** |  | [default to nothing]
+**available** | **Bool** |  | [default to nothing]
+**bus** | **Int64** |  | [default to nothing]
+**active_power** | **Float64** |  | [default to nothing]
 **reactive_power** | **Float64** |  | [default to nothing]
+**rating** | **Float64** |  | [default to nothing]
+**prime_mover_type** | **String** |  | [default to nothing]
+**active_power_limits** | [***MinMax**](MinMax.md) |  | [default to nothing]
 **reactive_power_limits** | [***MinMax**](MinMax.md) |  | [optional] [default to nothing]
+**ramp_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
 **time_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
+**base_power** | **Float64** |  | [default to nothing]
+**status** | **Bool** |  | [optional] [default to false]
+**time_at_status** | **Float64** |  | [optional] [default to 10000.0]
+**operation_cost** | [***HydroGenerationCost**](HydroGenerationCost.md) |  | [optional] [default to nothing]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 
-
 [[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
-
-

--- a/SiennaOpenAPIModels.jl/docs/HydroEnergyReservoir.md
+++ b/SiennaOpenAPIModels.jl/docs/HydroEnergyReservoir.md
@@ -1,7 +1,7 @@
 # HydroEnergyReservoir
 
-
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **active_power** | **Float64** |  | [default to nothing]
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **initial_storage** | **Float64** |  | [default to nothing]
 **name** | **String** |  | [default to nothing]
 **operation_cost** | [***HydroStorageGenerationCost**](HydroStorageGenerationCost.md) |  | [optional] [default to nothing]
-**prime_mover_type** | **String** |  | [default to "OT"]
+**prime_mover_type** | **String** |  | [default to nothing]
 **ramp_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
 **rating** | **Float64** |  | [default to nothing]
 **reactive_power** | **Float64** |  | [default to nothing]
@@ -27,7 +27,4 @@ Name | Type | Description | Notes
 **time_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 
-
 [[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
-
-

--- a/SiennaOpenAPIModels.jl/docs/HydroPumpTurbine.md
+++ b/SiennaOpenAPIModels.jl/docs/HydroPumpTurbine.md
@@ -21,14 +21,14 @@ Name | Type | Description | Notes
 **ramp_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
 **time_limits** | [***UpDown**](UpDown.md) |  | [optional] [default to nothing]
 **base_power** | **Float64** |  | [default to nothing]
+**status** | **String** |  | [optional] [default to "OFF"]
+**time_at_status** | **Float64** |  | [optional] [default to 10000.0]
 **operation_cost** | [***HydroStorageGenerationCost**](HydroStorageGenerationCost.md) |  | [optional] [default to nothing]
 **active_power_pump** | **Float64** |  | [optional] [default to 0.0]
 **efficiency** | [***TurbinePump**](TurbinePump.md) |  | [optional] [default to nothing]
 **transition_time** | [***TurbinePump**](TurbinePump.md) |  | [optional] [default to nothing]
 **minimum_time** | [***TurbinePump**](TurbinePump.md) |  | [optional] [default to nothing]
 **conversion_factor** | **Float64** |  | [optional] [default to 1.0]
-**must_run** | **Bool** |  | [optional] [default to false]
-**prime_mover_type** | **String** |  | [optional] [default to "OT"]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 
 [[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)

--- a/SiennaOpenAPIModels.jl/docs/HydroTurbine.md
+++ b/SiennaOpenAPIModels.jl/docs/HydroTurbine.md
@@ -20,6 +20,7 @@ Name | Type | Description | Notes
 **base_power** | **Float64** |  | [default to nothing]
 **operation_cost** | [***HydroGenerationCost**](HydroGenerationCost.md) |  | [optional] [default to nothing]
 **efficiency** | **Float64** |  | [optional] [default to 1.0]
+**turbine_type** | **String** |  | [optional] [default to "UNKNOWN"]
 **conversion_factor** | **Float64** |  | [optional] [default to 1.0]
 **reservoirs** | **Vector{Int64}** |  | [optional] [default to nothing]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]

--- a/SiennaOpenAPIModels.jl/docs/RenewableDispatch.md
+++ b/SiennaOpenAPIModels.jl/docs/RenewableDispatch.md
@@ -1,7 +1,7 @@
 # RenewableDispatch
 
-
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **Int64** |  | [default to nothing]
@@ -11,14 +11,11 @@ Name | Type | Description | Notes
 **active_power** | **Float64** |  | [default to nothing]
 **reactive_power** | **Float64** |  | [default to nothing]
 **rating** | **Float64** |  | [default to nothing]
-**prime_mover_type** | **String** |  | [default to "OT"]
+**prime_mover_type** | **String** |  | [default to nothing]
 **reactive_power_limits** | [***MinMax**](MinMax.md) |  | [optional] [default to nothing]
 **power_factor** | **Float64** |  | [default to nothing]
 **operation_cost** | [***RenewableGenerationCost**](RenewableGenerationCost.md) |  | [default to nothing]
 **base_power** | **Float64** |  | [default to nothing]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 
-
 [[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
-
-

--- a/SiennaOpenAPIModels.jl/docs/RenewableNonDispatch.md
+++ b/SiennaOpenAPIModels.jl/docs/RenewableNonDispatch.md
@@ -1,7 +1,7 @@
 # RenewableNonDispatch
 
-
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **Int64** |  | [default to nothing]
@@ -11,12 +11,9 @@ Name | Type | Description | Notes
 **active_power** | **Float64** |  | [default to nothing]
 **reactive_power** | **Float64** |  | [default to nothing]
 **rating** | **Float64** |  | [default to nothing]
-**prime_mover_type** | **String** |  | [default to "OT"]
+**prime_mover_type** | **String** |  | [default to nothing]
 **power_factor** | **Float64** |  | [default to nothing]
 **base_power** | **Float64** |  | [default to nothing]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 
-
 [[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
-
-

--- a/SiennaOpenAPIModels.jl/docs/SynchronousCondenser.md
+++ b/SiennaOpenAPIModels.jl/docs/SynchronousCondenser.md
@@ -12,7 +12,6 @@ Name | Type | Description | Notes
 **rating** | **Float64** |  | [default to nothing]
 **reactive_power_limits** | [***MinMax**](MinMax.md) |  | [optional] [default to nothing]
 **base_power** | **Float64** |  | [default to nothing]
-**must_run** | **Bool** |  | [optional] [default to false]
 **active_power_losses** | **Float64** |  | [optional] [default to 0.0]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 

--- a/SiennaOpenAPIModels.jl/docs/ThermalMultiStart.md
+++ b/SiennaOpenAPIModels.jl/docs/ThermalMultiStart.md
@@ -1,7 +1,7 @@
 # ThermalMultiStart
 
-
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **Int64** |  | [default to nothing]
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **active_power** | **Float64** |  | [default to nothing]
 **reactive_power** | **Float64** |  | [default to nothing]
 **rating** | **Float64** |  | [default to nothing]
-**prime_mover_type** | **String** |  | [default to "OT"]
+**prime_mover_type** | **String** |  | [default to nothing]
 **fuel** | **String** | Thermal fuels that reflect options in the EIA annual energy review. | [default to "OTHER"]
 **active_power_limits** | [***MinMax**](MinMax.md) |  | [default to nothing]
 **reactive_power_limits** | [***MinMax**](MinMax.md) |  | [optional] [default to nothing]
@@ -27,7 +27,4 @@ Name | Type | Description | Notes
 **must_run** | **Bool** |  | [optional] [default to false]
 **dynamic_injector** | **Any** |  | [optional] [default to nothing]
 
-
 [[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
-
-

--- a/SiennaOpenAPIModels.jl/src/json_to_sienna/common.jl
+++ b/SiennaOpenAPIModels.jl/src/json_to_sienna/common.jl
@@ -67,6 +67,10 @@ function get_storage_tech_enum(storage::String)
     IS.deserialize(PSY.StorageTech, storage)
 end
 
+function get_turbine_type_enum(turbine::String)
+    IS.deserialize(PSY.HydroTurbineType, turbine)
+end
+
 function get_winding_group_enum(group_num::String)
     IS.deserialize(PSY.WindingGroupNumber, group_num)
 end

--- a/SiennaOpenAPIModels.jl/src/json_to_sienna/static_injections.jl
+++ b/SiennaOpenAPIModels.jl/src/json_to_sienna/static_injections.jl
@@ -98,6 +98,8 @@ function openapi2psy(hydro::HydroDispatch, resolver::Resolver)
         ramp_limits=divide(get_tuple_up_down(hydro.ramp_limits), hydro.base_power),
         time_limits=get_tuple_up_down(hydro.time_limits),
         base_power=hydro.base_power,
+        status=hydro.status,
+        time_at_status=hydro.time_at_status,
         operation_cost=get_sienna_operation_cost(hydro.operation_cost),
     )
 end
@@ -166,14 +168,14 @@ function openapi2psy(hydro::HydroPumpTurbine, resolver::Resolver)
         ramp_limits=divide(get_tuple_up_down(hydro.ramp_limits), hydro.base_power),
         time_limits=get_tuple_up_down(hydro.time_limits),
         base_power=hydro.base_power,
+        status=get_pump_status_enum(hydro.status),
+        time_at_status=hydro.time_at_status,
         operation_cost=get_sienna_operation_cost(hydro.operation_cost),
         active_power_pump=hydro.active_power_pump / hydro.base_power,
         efficiency=get_tuple_turbine_pump(hydro.efficiency),
         transition_time=get_tuple_turbine_pump(hydro.transition_time),
         minimum_time=get_tuple_turbine_pump(hydro.minimum_time),
         conversion_factor=hydro.conversion_factor,
-        must_run=hydro.must_run,
-        prime_mover_type=get_prime_mover_enum(hydro.prime_mover_type),
     )
 end
 
@@ -221,6 +223,7 @@ function openapi2psy(hydro::HydroTurbine, resolver::Resolver)
         base_power=hydro.base_power,
         operation_cost=get_sienna_operation_cost(hydro.operation_cost),
         efficiency=hydro.efficiency,
+        turbine_type=get_turbine_type_enum(hydro.turbine_type),
         conversion_factor=hydro.conversion_factor,
         reservoirs=map(resolver, hydro.reservoirs), # this is a vector of reservoirs
     )
@@ -494,7 +497,6 @@ function openapi2psy(synch::SynchronousCondenser, resolver::Resolver)
             synch.base_power,
         ),
         base_power=synch.base_power,
-        must_run=synch.must_run,
         active_power_losses=synch.active_power_losses / synch.base_power,
     )
 end

--- a/SiennaOpenAPIModels.jl/src/models/model_HydroDispatch.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_HydroDispatch.jl
@@ -4,88 +4,98 @@
 @doc raw"""HydroDispatch
 
     HydroDispatch(;
-        active_power=nothing,
-        active_power_limits=nothing,
-        available=nothing,
-        base_power=nothing,
-        bus=nothing,
         id=nothing,
         name=nothing,
-        operation_cost=nothing,
-        prime_mover_type="OT",
-        ramp_limits=nothing,
-        rating=nothing,
+        available=nothing,
+        bus=nothing,
+        active_power=nothing,
         reactive_power=nothing,
+        rating=nothing,
+        prime_mover_type=nothing,
+        active_power_limits=nothing,
         reactive_power_limits=nothing,
+        ramp_limits=nothing,
         time_limits=nothing,
+        base_power=nothing,
+        status=false,
+        time_at_status=10000.0,
+        operation_cost=nothing,
         dynamic_injector=nothing,
     )
 
-    - active_power::Float64
-    - active_power_limits::MinMax
-    - available::Bool
-    - base_power::Float64
-    - bus::Int64
     - id::Int64
     - name::String
-    - operation_cost::HydroGenerationCost
-    - prime_mover_type::String
-    - ramp_limits::UpDown
-    - rating::Float64
+    - available::Bool
+    - bus::Int64
+    - active_power::Float64
     - reactive_power::Float64
+    - rating::Float64
+    - prime_mover_type::String
+    - active_power_limits::MinMax
     - reactive_power_limits::MinMax
+    - ramp_limits::UpDown
     - time_limits::UpDown
+    - base_power::Float64
+    - status::Bool
+    - time_at_status::Float64
+    - operation_cost::HydroGenerationCost
     - dynamic_injector::Any
 """
 Base.@kwdef mutable struct HydroDispatch <: OpenAPI.APIModel
-    active_power::Union{Nothing, Float64} = nothing
-    active_power_limits = nothing # spec type: Union{ Nothing, MinMax }
-    available::Union{Nothing, Bool} = nothing
-    base_power::Union{Nothing, Float64} = nothing
-    bus::Union{Nothing, Int64} = nothing
     id::Union{Nothing, Int64} = nothing
     name::Union{Nothing, String} = nothing
-    operation_cost = nothing # spec type: Union{ Nothing, HydroGenerationCost }
-    prime_mover_type::Union{Nothing, String} = "OT"
-    ramp_limits = nothing # spec type: Union{ Nothing, UpDown }
-    rating::Union{Nothing, Float64} = nothing
+    available::Union{Nothing, Bool} = nothing
+    bus::Union{Nothing, Int64} = nothing
+    active_power::Union{Nothing, Float64} = nothing
     reactive_power::Union{Nothing, Float64} = nothing
+    rating::Union{Nothing, Float64} = nothing
+    prime_mover_type::Union{Nothing, String} = nothing
+    active_power_limits = nothing # spec type: Union{ Nothing, MinMax }
     reactive_power_limits = nothing # spec type: Union{ Nothing, MinMax }
+    ramp_limits = nothing # spec type: Union{ Nothing, UpDown }
     time_limits = nothing # spec type: Union{ Nothing, UpDown }
+    base_power::Union{Nothing, Float64} = nothing
+    status::Union{Nothing, Bool} = false
+    time_at_status::Union{Nothing, Float64} = 10000.0
+    operation_cost = nothing # spec type: Union{ Nothing, HydroGenerationCost }
     dynamic_injector::Union{Nothing, Any} = nothing
 
     function HydroDispatch(
-        active_power,
-        active_power_limits,
-        available,
-        base_power,
-        bus,
         id,
         name,
-        operation_cost,
-        prime_mover_type,
-        ramp_limits,
-        rating,
+        available,
+        bus,
+        active_power,
         reactive_power,
+        rating,
+        prime_mover_type,
+        active_power_limits,
         reactive_power_limits,
+        ramp_limits,
         time_limits,
+        base_power,
+        status,
+        time_at_status,
+        operation_cost,
         dynamic_injector,
     )
         o = new(
-            active_power,
-            active_power_limits,
-            available,
-            base_power,
-            bus,
             id,
             name,
-            operation_cost,
-            prime_mover_type,
-            ramp_limits,
-            rating,
+            available,
+            bus,
+            active_power,
             reactive_power,
+            rating,
+            prime_mover_type,
+            active_power_limits,
             reactive_power_limits,
+            ramp_limits,
             time_limits,
+            base_power,
+            status,
+            time_at_status,
+            operation_cost,
             dynamic_injector,
         )
         OpenAPI.validate_properties(o)
@@ -94,62 +104,66 @@ Base.@kwdef mutable struct HydroDispatch <: OpenAPI.APIModel
 end # type HydroDispatch
 
 const _property_types_HydroDispatch = Dict{Symbol, String}(
-    Symbol("active_power") => "Float64",
-    Symbol("active_power_limits") => "MinMax",
-    Symbol("available") => "Bool",
-    Symbol("base_power") => "Float64",
-    Symbol("bus") => "Int64",
     Symbol("id") => "Int64",
     Symbol("name") => "String",
-    Symbol("operation_cost") => "HydroGenerationCost",
-    Symbol("prime_mover_type") => "String",
-    Symbol("ramp_limits") => "UpDown",
-    Symbol("rating") => "Float64",
+    Symbol("available") => "Bool",
+    Symbol("bus") => "Int64",
+    Symbol("active_power") => "Float64",
     Symbol("reactive_power") => "Float64",
+    Symbol("rating") => "Float64",
+    Symbol("prime_mover_type") => "String",
+    Symbol("active_power_limits") => "MinMax",
     Symbol("reactive_power_limits") => "MinMax",
+    Symbol("ramp_limits") => "UpDown",
     Symbol("time_limits") => "UpDown",
+    Symbol("base_power") => "Float64",
+    Symbol("status") => "Bool",
+    Symbol("time_at_status") => "Float64",
+    Symbol("operation_cost") => "HydroGenerationCost",
     Symbol("dynamic_injector") => "Any",
 )
 OpenAPI.property_type(::Type{HydroDispatch}, name::Symbol) =
     Union{Nothing, eval(Base.Meta.parse(_property_types_HydroDispatch[name]))}
 
 function OpenAPI.check_required(o::HydroDispatch)
-    o.active_power === nothing && (return false)
-    o.active_power_limits === nothing && (return false)
-    o.available === nothing && (return false)
-    o.base_power === nothing && (return false)
-    o.bus === nothing && (return false)
     o.id === nothing && (return false)
     o.name === nothing && (return false)
-    o.prime_mover_type === nothing && (return false)
-    o.rating === nothing && (return false)
+    o.available === nothing && (return false)
+    o.bus === nothing && (return false)
+    o.active_power === nothing && (return false)
     o.reactive_power === nothing && (return false)
+    o.rating === nothing && (return false)
+    o.prime_mover_type === nothing && (return false)
+    o.active_power_limits === nothing && (return false)
+    o.base_power === nothing && (return false)
     true
 end
 
 function OpenAPI.validate_properties(o::HydroDispatch)
+    OpenAPI.validate_property(HydroDispatch, Symbol("id"), o.id)
+    OpenAPI.validate_property(HydroDispatch, Symbol("name"), o.name)
+    OpenAPI.validate_property(HydroDispatch, Symbol("available"), o.available)
+    OpenAPI.validate_property(HydroDispatch, Symbol("bus"), o.bus)
     OpenAPI.validate_property(HydroDispatch, Symbol("active_power"), o.active_power)
+    OpenAPI.validate_property(HydroDispatch, Symbol("reactive_power"), o.reactive_power)
+    OpenAPI.validate_property(HydroDispatch, Symbol("rating"), o.rating)
+    OpenAPI.validate_property(HydroDispatch, Symbol("prime_mover_type"), o.prime_mover_type)
     OpenAPI.validate_property(
         HydroDispatch,
         Symbol("active_power_limits"),
         o.active_power_limits,
     )
-    OpenAPI.validate_property(HydroDispatch, Symbol("available"), o.available)
-    OpenAPI.validate_property(HydroDispatch, Symbol("base_power"), o.base_power)
-    OpenAPI.validate_property(HydroDispatch, Symbol("bus"), o.bus)
-    OpenAPI.validate_property(HydroDispatch, Symbol("id"), o.id)
-    OpenAPI.validate_property(HydroDispatch, Symbol("name"), o.name)
-    OpenAPI.validate_property(HydroDispatch, Symbol("operation_cost"), o.operation_cost)
-    OpenAPI.validate_property(HydroDispatch, Symbol("prime_mover_type"), o.prime_mover_type)
-    OpenAPI.validate_property(HydroDispatch, Symbol("ramp_limits"), o.ramp_limits)
-    OpenAPI.validate_property(HydroDispatch, Symbol("rating"), o.rating)
-    OpenAPI.validate_property(HydroDispatch, Symbol("reactive_power"), o.reactive_power)
     OpenAPI.validate_property(
         HydroDispatch,
         Symbol("reactive_power_limits"),
         o.reactive_power_limits,
     )
+    OpenAPI.validate_property(HydroDispatch, Symbol("ramp_limits"), o.ramp_limits)
     OpenAPI.validate_property(HydroDispatch, Symbol("time_limits"), o.time_limits)
+    OpenAPI.validate_property(HydroDispatch, Symbol("base_power"), o.base_power)
+    OpenAPI.validate_property(HydroDispatch, Symbol("status"), o.status)
+    OpenAPI.validate_property(HydroDispatch, Symbol("time_at_status"), o.time_at_status)
+    OpenAPI.validate_property(HydroDispatch, Symbol("operation_cost"), o.operation_cost)
     OpenAPI.validate_property(HydroDispatch, Symbol("dynamic_injector"), o.dynamic_injector)
 end
 

--- a/SiennaOpenAPIModels.jl/src/models/model_HydroEnergyReservoir.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_HydroEnergyReservoir.jl
@@ -15,7 +15,7 @@
         initial_storage=nothing,
         name=nothing,
         operation_cost=nothing,
-        prime_mover_type="OT",
+        prime_mover_type=nothing,
         ramp_limits=nothing,
         rating=nothing,
         reactive_power=nothing,
@@ -63,7 +63,7 @@ Base.@kwdef mutable struct HydroEnergyReservoir <: OpenAPI.APIModel
     initial_storage::Union{Nothing, Float64} = nothing
     name::Union{Nothing, String} = nothing
     operation_cost = nothing # spec type: Union{ Nothing, HydroStorageGenerationCost }
-    prime_mover_type::Union{Nothing, String} = "OT"
+    prime_mover_type::Union{Nothing, String} = nothing
     ramp_limits = nothing # spec type: Union{ Nothing, UpDown }
     rating::Union{Nothing, Float64} = nothing
     reactive_power::Union{Nothing, Float64} = nothing

--- a/SiennaOpenAPIModels.jl/src/models/model_HydroPumpTurbine.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_HydroPumpTurbine.jl
@@ -21,14 +21,14 @@
         ramp_limits=nothing,
         time_limits=nothing,
         base_power=nothing,
+        status="OFF",
+        time_at_status=10000.0,
         operation_cost=nothing,
         active_power_pump=0.0,
         efficiency=nothing,
         transition_time=nothing,
         minimum_time=nothing,
         conversion_factor=1.0,
-        must_run=false,
-        prime_mover_type="OT",
         dynamic_injector=nothing,
     )
 
@@ -49,14 +49,14 @@
     - ramp_limits::UpDown
     - time_limits::UpDown
     - base_power::Float64
+    - status::String
+    - time_at_status::Float64
     - operation_cost::HydroStorageGenerationCost
     - active_power_pump::Float64
     - efficiency::TurbinePump
     - transition_time::TurbinePump
     - minimum_time::TurbinePump
     - conversion_factor::Float64
-    - must_run::Bool
-    - prime_mover_type::String
     - dynamic_injector::Any
 """
 Base.@kwdef mutable struct HydroPumpTurbine <: OpenAPI.APIModel
@@ -77,14 +77,14 @@ Base.@kwdef mutable struct HydroPumpTurbine <: OpenAPI.APIModel
     ramp_limits = nothing # spec type: Union{ Nothing, UpDown }
     time_limits = nothing # spec type: Union{ Nothing, UpDown }
     base_power::Union{Nothing, Float64} = nothing
+    status::Union{Nothing, String} = "OFF"
+    time_at_status::Union{Nothing, Float64} = 10000.0
     operation_cost = nothing # spec type: Union{ Nothing, HydroStorageGenerationCost }
     active_power_pump::Union{Nothing, Float64} = 0.0
     efficiency = nothing # spec type: Union{ Nothing, TurbinePump }
     transition_time = nothing # spec type: Union{ Nothing, TurbinePump }
     minimum_time = nothing # spec type: Union{ Nothing, TurbinePump }
     conversion_factor::Union{Nothing, Float64} = 1.0
-    must_run::Union{Nothing, Bool} = false
-    prime_mover_type::Union{Nothing, String} = "OT"
     dynamic_injector::Union{Nothing, Any} = nothing
 
     function HydroPumpTurbine(
@@ -105,14 +105,14 @@ Base.@kwdef mutable struct HydroPumpTurbine <: OpenAPI.APIModel
         ramp_limits,
         time_limits,
         base_power,
+        status,
+        time_at_status,
         operation_cost,
         active_power_pump,
         efficiency,
         transition_time,
         minimum_time,
         conversion_factor,
-        must_run,
-        prime_mover_type,
         dynamic_injector,
     )
         o = new(
@@ -133,14 +133,14 @@ Base.@kwdef mutable struct HydroPumpTurbine <: OpenAPI.APIModel
             ramp_limits,
             time_limits,
             base_power,
+            status,
+            time_at_status,
             operation_cost,
             active_power_pump,
             efficiency,
             transition_time,
             minimum_time,
             conversion_factor,
-            must_run,
-            prime_mover_type,
             dynamic_injector,
         )
         OpenAPI.validate_properties(o)
@@ -166,14 +166,14 @@ const _property_types_HydroPumpTurbine = Dict{Symbol, String}(
     Symbol("ramp_limits") => "UpDown",
     Symbol("time_limits") => "UpDown",
     Symbol("base_power") => "Float64",
+    Symbol("status") => "String",
+    Symbol("time_at_status") => "Float64",
     Symbol("operation_cost") => "HydroStorageGenerationCost",
     Symbol("active_power_pump") => "Float64",
     Symbol("efficiency") => "TurbinePump",
     Symbol("transition_time") => "TurbinePump",
     Symbol("minimum_time") => "TurbinePump",
     Symbol("conversion_factor") => "Float64",
-    Symbol("must_run") => "Bool",
-    Symbol("prime_mover_type") => "String",
     Symbol("dynamic_injector") => "Any",
 )
 OpenAPI.property_type(::Type{HydroPumpTurbine}, name::Symbol) =
@@ -230,6 +230,8 @@ function OpenAPI.validate_properties(o::HydroPumpTurbine)
     OpenAPI.validate_property(HydroPumpTurbine, Symbol("ramp_limits"), o.ramp_limits)
     OpenAPI.validate_property(HydroPumpTurbine, Symbol("time_limits"), o.time_limits)
     OpenAPI.validate_property(HydroPumpTurbine, Symbol("base_power"), o.base_power)
+    OpenAPI.validate_property(HydroPumpTurbine, Symbol("status"), o.status)
+    OpenAPI.validate_property(HydroPumpTurbine, Symbol("time_at_status"), o.time_at_status)
     OpenAPI.validate_property(HydroPumpTurbine, Symbol("operation_cost"), o.operation_cost)
     OpenAPI.validate_property(
         HydroPumpTurbine,
@@ -248,12 +250,6 @@ function OpenAPI.validate_properties(o::HydroPumpTurbine)
         Symbol("conversion_factor"),
         o.conversion_factor,
     )
-    OpenAPI.validate_property(HydroPumpTurbine, Symbol("must_run"), o.must_run)
-    OpenAPI.validate_property(
-        HydroPumpTurbine,
-        Symbol("prime_mover_type"),
-        o.prime_mover_type,
-    )
     OpenAPI.validate_property(
         HydroPumpTurbine,
         Symbol("dynamic_injector"),
@@ -262,37 +258,7 @@ function OpenAPI.validate_properties(o::HydroPumpTurbine)
 end
 
 function OpenAPI.validate_property(::Type{HydroPumpTurbine}, name::Symbol, val)
-    if name === Symbol("prime_mover_type")
-        OpenAPI.validate_param(
-            name,
-            "HydroPumpTurbine",
-            :enum,
-            val,
-            [
-                "BA",
-                "BT",
-                "CA",
-                "CC",
-                "CE",
-                "CP",
-                "CS",
-                "CT",
-                "ES",
-                "FC",
-                "FW",
-                "GT",
-                "HA",
-                "HB",
-                "HK",
-                "HY",
-                "IC",
-                "PS",
-                "OT",
-                "ST",
-                "PVe",
-                "WT",
-                "WS",
-            ],
-        )
+    if name === Symbol("status")
+        OpenAPI.validate_param(name, "HydroPumpTurbine", :enum, val, ["PUMP", "GEN", "OFF"])
     end
 end

--- a/SiennaOpenAPIModels.jl/src/models/model_HydroTurbine.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_HydroTurbine.jl
@@ -20,6 +20,7 @@
         base_power=nothing,
         operation_cost=nothing,
         efficiency=1.0,
+        turbine_type="UNKNOWN",
         conversion_factor=1.0,
         reservoirs=nothing,
         dynamic_injector=nothing,
@@ -41,6 +42,7 @@
     - base_power::Float64
     - operation_cost::HydroGenerationCost
     - efficiency::Float64
+    - turbine_type::String
     - conversion_factor::Float64
     - reservoirs::Vector{Int64}
     - dynamic_injector::Any
@@ -62,6 +64,7 @@ Base.@kwdef mutable struct HydroTurbine <: OpenAPI.APIModel
     base_power::Union{Nothing, Float64} = nothing
     operation_cost = nothing # spec type: Union{ Nothing, HydroGenerationCost }
     efficiency::Union{Nothing, Float64} = 1.0
+    turbine_type::Union{Nothing, String} = "UNKNOWN"
     conversion_factor::Union{Nothing, Float64} = 1.0
     reservoirs::Union{Nothing, Vector{Int64}} = nothing
     dynamic_injector::Union{Nothing, Any} = nothing
@@ -83,6 +86,7 @@ Base.@kwdef mutable struct HydroTurbine <: OpenAPI.APIModel
         base_power,
         operation_cost,
         efficiency,
+        turbine_type,
         conversion_factor,
         reservoirs,
         dynamic_injector,
@@ -104,6 +108,7 @@ Base.@kwdef mutable struct HydroTurbine <: OpenAPI.APIModel
             base_power,
             operation_cost,
             efficiency,
+            turbine_type,
             conversion_factor,
             reservoirs,
             dynamic_injector,
@@ -130,6 +135,7 @@ const _property_types_HydroTurbine = Dict{Symbol, String}(
     Symbol("base_power") => "Float64",
     Symbol("operation_cost") => "HydroGenerationCost",
     Symbol("efficiency") => "Float64",
+    Symbol("turbine_type") => "String",
     Symbol("conversion_factor") => "Float64",
     Symbol("reservoirs") => "Vector{Int64}",
     Symbol("dynamic_injector") => "Any",
@@ -180,6 +186,7 @@ function OpenAPI.validate_properties(o::HydroTurbine)
     OpenAPI.validate_property(HydroTurbine, Symbol("base_power"), o.base_power)
     OpenAPI.validate_property(HydroTurbine, Symbol("operation_cost"), o.operation_cost)
     OpenAPI.validate_property(HydroTurbine, Symbol("efficiency"), o.efficiency)
+    OpenAPI.validate_property(HydroTurbine, Symbol("turbine_type"), o.turbine_type)
     OpenAPI.validate_property(
         HydroTurbine,
         Symbol("conversion_factor"),
@@ -189,4 +196,25 @@ function OpenAPI.validate_properties(o::HydroTurbine)
     OpenAPI.validate_property(HydroTurbine, Symbol("dynamic_injector"), o.dynamic_injector)
 end
 
-function OpenAPI.validate_property(::Type{HydroTurbine}, name::Symbol, val) end
+function OpenAPI.validate_property(::Type{HydroTurbine}, name::Symbol, val)
+    if name === Symbol("turbine_type")
+        OpenAPI.validate_param(
+            name,
+            "HydroTurbine",
+            :enum,
+            val,
+            [
+                "UNKNOWN",
+                "PELTON",
+                "FRANCIS",
+                "KAPLAN",
+                "TURGO",
+                "CROSSFLOW",
+                "BULB",
+                "DERIAZ",
+                "PROPELLER",
+                "OTHER",
+            ],
+        )
+    end
+end

--- a/SiennaOpenAPIModels.jl/src/models/model_RenewableDispatch.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_RenewableDispatch.jl
@@ -11,7 +11,7 @@
         active_power=nothing,
         reactive_power=nothing,
         rating=nothing,
-        prime_mover_type="OT",
+        prime_mover_type=nothing,
         reactive_power_limits=nothing,
         power_factor=nothing,
         operation_cost=nothing,
@@ -41,7 +41,7 @@ Base.@kwdef mutable struct RenewableDispatch <: OpenAPI.APIModel
     active_power::Union{Nothing, Float64} = nothing
     reactive_power::Union{Nothing, Float64} = nothing
     rating::Union{Nothing, Float64} = nothing
-    prime_mover_type::Union{Nothing, String} = "OT"
+    prime_mover_type::Union{Nothing, String} = nothing
     reactive_power_limits = nothing # spec type: Union{ Nothing, MinMax }
     power_factor::Union{Nothing, Float64} = nothing
     operation_cost = nothing # spec type: Union{ Nothing, RenewableGenerationCost }

--- a/SiennaOpenAPIModels.jl/src/models/model_RenewableNonDispatch.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_RenewableNonDispatch.jl
@@ -11,7 +11,7 @@
         active_power=nothing,
         reactive_power=nothing,
         rating=nothing,
-        prime_mover_type="OT",
+        prime_mover_type=nothing,
         power_factor=nothing,
         base_power=nothing,
         dynamic_injector=nothing,
@@ -37,7 +37,7 @@ Base.@kwdef mutable struct RenewableNonDispatch <: OpenAPI.APIModel
     active_power::Union{Nothing, Float64} = nothing
     reactive_power::Union{Nothing, Float64} = nothing
     rating::Union{Nothing, Float64} = nothing
-    prime_mover_type::Union{Nothing, String} = "OT"
+    prime_mover_type::Union{Nothing, String} = nothing
     power_factor::Union{Nothing, Float64} = nothing
     base_power::Union{Nothing, Float64} = nothing
     dynamic_injector::Union{Nothing, Any} = nothing

--- a/SiennaOpenAPIModels.jl/src/models/model_SynchronousCondenser.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_SynchronousCondenser.jl
@@ -12,7 +12,6 @@
         rating=nothing,
         reactive_power_limits=nothing,
         base_power=nothing,
-        must_run=false,
         active_power_losses=0.0,
         dynamic_injector=nothing,
     )
@@ -25,7 +24,6 @@
     - rating::Float64
     - reactive_power_limits::MinMax
     - base_power::Float64
-    - must_run::Bool
     - active_power_losses::Float64
     - dynamic_injector::Any
 """
@@ -38,7 +36,6 @@ Base.@kwdef mutable struct SynchronousCondenser <: OpenAPI.APIModel
     rating::Union{Nothing, Float64} = nothing
     reactive_power_limits = nothing # spec type: Union{ Nothing, MinMax }
     base_power::Union{Nothing, Float64} = nothing
-    must_run::Union{Nothing, Bool} = false
     active_power_losses::Union{Nothing, Float64} = 0.0
     dynamic_injector::Union{Nothing, Any} = nothing
 
@@ -51,7 +48,6 @@ Base.@kwdef mutable struct SynchronousCondenser <: OpenAPI.APIModel
         rating,
         reactive_power_limits,
         base_power,
-        must_run,
         active_power_losses,
         dynamic_injector,
     )
@@ -64,7 +60,6 @@ Base.@kwdef mutable struct SynchronousCondenser <: OpenAPI.APIModel
             rating,
             reactive_power_limits,
             base_power,
-            must_run,
             active_power_losses,
             dynamic_injector,
         )
@@ -82,7 +77,6 @@ const _property_types_SynchronousCondenser = Dict{Symbol, String}(
     Symbol("rating") => "Float64",
     Symbol("reactive_power_limits") => "MinMax",
     Symbol("base_power") => "Float64",
-    Symbol("must_run") => "Bool",
     Symbol("active_power_losses") => "Float64",
     Symbol("dynamic_injector") => "Any",
 )
@@ -117,7 +111,6 @@ function OpenAPI.validate_properties(o::SynchronousCondenser)
         o.reactive_power_limits,
     )
     OpenAPI.validate_property(SynchronousCondenser, Symbol("base_power"), o.base_power)
-    OpenAPI.validate_property(SynchronousCondenser, Symbol("must_run"), o.must_run)
     OpenAPI.validate_property(
         SynchronousCondenser,
         Symbol("active_power_losses"),

--- a/SiennaOpenAPIModels.jl/src/models/model_ThermalMultiStart.jl
+++ b/SiennaOpenAPIModels.jl/src/models/model_ThermalMultiStart.jl
@@ -12,7 +12,7 @@
         active_power=nothing,
         reactive_power=nothing,
         rating=nothing,
-        prime_mover_type="OT",
+        prime_mover_type=nothing,
         fuel="OTHER",
         active_power_limits=nothing,
         reactive_power_limits=nothing,
@@ -60,7 +60,7 @@ Base.@kwdef mutable struct ThermalMultiStart <: OpenAPI.APIModel
     active_power::Union{Nothing, Float64} = nothing
     reactive_power::Union{Nothing, Float64} = nothing
     rating::Union{Nothing, Float64} = nothing
-    prime_mover_type::Union{Nothing, String} = "OT"
+    prime_mover_type::Union{Nothing, String} = nothing
     fuel::Union{Nothing, String} = "OTHER"
     active_power_limits = nothing # spec type: Union{ Nothing, MinMax }
     reactive_power_limits = nothing # spec type: Union{ Nothing, MinMax }

--- a/SiennaOpenAPIModels.jl/src/sienna_to_json/static_injections.jl
+++ b/SiennaOpenAPIModels.jl/src/sienna_to_json/static_injections.jl
@@ -100,6 +100,8 @@ function psy2openapi(hydro::PSY.HydroDispatch, ids::IDGenerator)
         operation_cost=get_operation_cost(hydro.operation_cost),
         rating=hydro.rating * hydro.base_power,
         base_power=hydro.base_power,
+        status=hydro.status,
+        time_at_status=hydro.time_at_status,
         time_limits=get_up_down(hydro.time_limits),
         dynamic_injector=getid!(ids, hydro.dynamic_injector),
     )
@@ -167,14 +169,14 @@ function psy2openapi(hydro::PSY.HydroPumpTurbine, ids::IDGenerator)
         ramp_limits=get_up_down(scale(hydro.ramp_limits, hydro.base_power)),
         time_limits=get_up_down(hydro.time_limits),
         base_power=hydro.base_power,
+        status=string(hydro.status),
+        time_at_status=hydro.time_at_status,
         operation_cost=HydroStorageGenerationCost(get_operation_cost(hydro.operation_cost)),
         active_power_pump=hydro.active_power_pump * hydro.base_power,
         efficiency=get_turbine_pump(hydro.efficiency),
         transition_time=get_turbine_pump(hydro.transition_time),
         minimum_time=get_turbine_pump(hydro.minimum_time),
         conversion_factor=hydro.conversion_factor,
-        must_run=hydro.must_run,
-        prime_mover_type=string(hydro.prime_mover_type),
         dynamic_injector=getid!(ids, hydro.dynamic_injector),
     )
 end
@@ -221,6 +223,7 @@ function psy2openapi(hydro::PSY.HydroTurbine, ids::IDGenerator)
         base_power=hydro.base_power,
         operation_cost=get_operation_cost(hydro.operation_cost),
         efficiency=hydro.efficiency,
+        turbine_type=string(hydro.turbine_type),
         conversion_factor=hydro.conversion_factor,
         reservoirs=map(c -> getid!(ids, c), hydro.reservoirs), # this is a vector of reservoirs
         dynamic_injector=getid!(ids, hydro.dynamic_injector),
@@ -509,7 +512,6 @@ function psy2openapi(synch::PSY.SynchronousCondenser, ids::IDGenerator)
             scale(synch.reactive_power_limits, synch.base_power),
         ),
         base_power=synch.base_power,
-        must_run=synch.must_run,
         active_power_losses=synch.active_power_losses * synch.base_power,
         dynamic_injector=getid!(ids, synch.dynamic_injector),
     )

--- a/SiennaOpenAPIModels.jl/test/test-basic-roundtrip.jl
+++ b/SiennaOpenAPIModels.jl/test/test-basic-roundtrip.jl
@@ -159,6 +159,8 @@ end
         @test test_convert.available
         @test test_convert.bus == 2
         @test test_convert.active_power == 3200.0
+        @test test_convert.status == "OFF"
+        @test test_convert.time_at_status == 10000.0
         @test test_convert.time_limits.down == 5.0
     end
     @testset "HydroReservoir to JSON" begin
@@ -200,6 +202,7 @@ end
             ramp_limits=(up=0.0, down=50.0),
             time_limits=(up=0.0, down=5.0),
             base_power=100.0,
+            turbine_type=PSY.HydroTurbineType.BULB,
         )
         PSY.add_component!(c_sys5, turbine)
         @test isa(turbine, PSY.HydroTurbine)
@@ -210,6 +213,7 @@ end
         @test test_convert.bus == 2
         @test test_convert.active_power == 3200.0
         @test test_convert.time_limits.down == 5.0
+        @test test_convert.turbine_type == "BULB"
     end
     @testset "InterruptibleStandardLoad to JSON" begin
         interrupt = PSY.InterruptibleStandardLoad(

--- a/SiennaOpenAPIModels.jl/test/test-complete-roundtrip.jl
+++ b/SiennaOpenAPIModels.jl/test/test-complete-roundtrip.jl
@@ -139,6 +139,7 @@ using JSON
             ramp_limits=(up=0.0, down=50.0),
             time_limits=(up=0.0, down=5.0),
             base_power=100.0,
+            turbine_type=PSY.HydroTurbineType.BULB,
         )
         PSY.add_component!(c_sys5, turbine)
         @test isa(turbine, PSY.HydroTurbine)


### PR DESCRIPTION
added psy5 changes to src/sienna_to_json, src/json_to_sienna, and to the basic and complete roundtrip test scripts and all those tests are passing. I cant see why but test-db.jl is failing at c_sys5_phes_ed to db because of a HydroPumpTurbine not being up to date with the current changes to psy5, but I made sure to clear all serialized systems before running the tests so in theory it shouldnt be because of that